### PR TITLE
#38 Get single task info

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ const result = await client.tasks.getTask(1);
   total_hours: 1860.192,
   entries: {
     count: 932,
-    url: 'https://secure.tickspot.com/114217/api/v2/tasks/14541833/entries.json',
+    url: 'https://secure.tickspot.com/654321/api/v2/tasks/14541833/entries.json',
     updated_at: '2021-12-16T16:11:14.000-05:00'
   },
   project: {
@@ -483,7 +483,7 @@ const result = await client.tasks.getTask(1);
     recurring: false,
     client_id: 365968,
     owner_id: 324080,
-    url: 'https://secure.tickspot.com/114217/api/v2/projects/2.json',
+    url: 'https://secure.tickspot.com/654321/api/v2/projects/2.json',
     created_at: '2020-04-21T16:06:53.000-04:00',
     updated_at: '2022-02-10T19:22:45.000-05:00'
   }

--- a/README.md
+++ b/README.md
@@ -447,7 +447,77 @@ const result = await client.tasks.listOpened(callback);
   ...
 ]
 ```
+#### Get Single Task
 
+This method will return the specified task. This method needs the following params:
+
+- [Required] taskId, task unique identificator.
+
+```javascript
+const result = await client.tasks.getTask(1);
+
+// The result would be something like the following:
+{
+  id: 1,
+  name: 'Software Development',
+  budget: null,
+  position: 1,
+  project_id: 2,
+  date_closed: null,
+  billable: false,
+  created_at: '2020-04-21T16:06:53.000-04:00',
+  updated_at: '2022-01-17T17:51:25.000-05:00',
+  total_hours: 1860.192,
+  entries: {
+    count: 932,
+    url: 'https://secure.tickspot.com/114217/api/v2/tasks/14541833/entries.json',
+    updated_at: '2021-12-16T16:11:14.000-05:00'
+  },
+  project: {
+    id: 2,
+    name: 'Internal Projects',
+    budget: null,
+    date_closed: null,
+    notifications: false,
+    billable: false,
+    recurring: false,
+    client_id: 365968,
+    owner_id: 324080,
+    url: 'https://secure.tickspot.com/114217/api/v2/projects/2.json',
+    created_at: '2020-04-21T16:06:53.000-04:00',
+    updated_at: '2022-02-10T19:22:45.000-05:00'
+  }
+}
+
+```
+
+Optionally, You can send a callback to perform an action on the response data. e.g:
+
+```javascript
+const callback = (responseData) => {
+  const date = new Date(responseData.created_at);
+  return {
+    id: responseData.id,
+    name: responseData.name,
+    projectName: responseData.project.name,
+    day: date.getDate(),
+    month: date.getMonth(),
+    year: date.getFullYear(),
+  };
+};
+
+const result = await client.tasks.getTask(1, callback);
+
+// The result would be something like the following:
+{
+  id: 1,
+  name: 'Software Development',
+  projectName: 'Internal Projects',
+  day: 21,
+  month: 3,
+  year: 2020
+}
+```
 ## Code of conduct
 
 We welcome everyone to contribute. Make sure you have read the [CODE_OF_CONDUCT][coc] before.

--- a/src/v2/resources/tasks.js
+++ b/src/v2/resources/tasks.js
@@ -28,6 +28,21 @@ class Tasks extends BaseResource {
     const URL = `${this.baseURL}/tasks.json`;
     return this.makeRequest({ URL, method: 'get', responseCallback });
   }
+
+  /**
+   * This method will return the specified task.
+   * @param {Number} taskId, task unique identificator.
+   * @param {callback} responseCallback
+   *    is an optional function to perform a process over the response data.
+   *
+   * @returns {object} task data on tickspot or an error if the process fails.
+   */
+  async getTask(taskId, responseCallback) {
+    if (!taskId) throw new Error('taskId field is missing');
+
+    const URL = `${this.baseURL}/tasks/${taskId}.json`;
+    return this.makeRequest({ URL, method: 'get', responseCallback });
+  }
 }
 
 export default Tasks;

--- a/test/v2/fixture/tasks/getTaskFixture.js
+++ b/test/v2/fixture/tasks/getTaskFixture.js
@@ -1,0 +1,33 @@
+const getTaskResponse = {
+  id: 123456,
+  name: 'Software Development',
+  budget: null,
+  position: 1,
+  project_id: 1,
+  date_closed: null,
+  billable: false,
+  created_at: '2020-04-21T16:06:53.000-04:00',
+  updated_at: '2022-01-17T17:51:25.000-05:00',
+  total_hours: 1860.192,
+  entries: {
+    count: 932,
+    url: 'https://secure.tickspot.com/114217/api/v2/tasks/123456/entries.json',
+    updated_at: '2021-12-16T16:11:14.000-05:00',
+  },
+  project: {
+    id: 1,
+    name: 'Internal Projects',
+    budget: null,
+    date_closed: null,
+    notifications: false,
+    billable: false,
+    recurring: false,
+    client_id: 365968,
+    owner_id: 324080,
+    url: 'https://secure.tickspot.com/114217/api/v2/projects/1.json',
+    created_at: '2020-04-21T16:06:53.000-04:00',
+    updated_at: '2022-02-10T19:22:45.000-05:00',
+  },
+};
+
+export default getTaskResponse;

--- a/test/v2/fixture/tasks/getTaskFixture.js
+++ b/test/v2/fixture/tasks/getTaskFixture.js
@@ -1,4 +1,4 @@
-const getTaskResponse = {
+const getTaskFixture = {
   id: 123456,
   name: 'Software Development',
   budget: null,
@@ -11,7 +11,7 @@ const getTaskResponse = {
   total_hours: 1860.192,
   entries: {
     count: 932,
-    url: 'https://secure.tickspot.com/114217/api/v2/tasks/123456/entries.json',
+    url: 'https://secure.tickspot.com/654321/api/v2/tasks/123456/entries.json',
     updated_at: '2021-12-16T16:11:14.000-05:00',
   },
   project: {
@@ -24,10 +24,10 @@ const getTaskResponse = {
     recurring: false,
     client_id: 365968,
     owner_id: 324080,
-    url: 'https://secure.tickspot.com/114217/api/v2/projects/1.json',
+    url: 'https://secure.tickspot.com/654321/api/v2/projects/1.json',
     created_at: '2020-04-21T16:06:53.000-04:00',
     updated_at: '2022-02-10T19:22:45.000-05:00',
   },
 };
 
-export default getTaskResponse;
+export default getTaskFixture;

--- a/test/v2/resources/tasks/getTask.test.js
+++ b/test/v2/resources/tasks/getTask.test.js
@@ -1,0 +1,82 @@
+import axios from 'axios';
+import tickspot from '#src/index';
+import responseFactory from '#test/v2/factories/responseFactory';
+import userInfo from '#test/v2/fixture/client';
+import successfulResponseData from '#test/v2/fixture/tasks/getTaskFixture';
+import notFoundTests from '#test/v2/shared/notFound';
+import authenticationErrorTests from '#test/v2/shared/authentication';
+import {
+  badResponseCallbackTests,
+  validResponseCallbackTests,
+} from '#test/v2/shared/responseCallback';
+import wrongParamsTests from '#test/v2/shared/wrongParams';
+
+jest.mock('axios');
+const client = tickspot({ apiVersion: 2, ...userInfo });
+const URL = `${client.baseURL}/tasks/123456.json`;
+
+describe('#getTask', () => {
+  beforeEach(() => {
+    axios.get.mockClear();
+  });
+
+  describe('when API call is successful', () => {
+    const requestResponse = responseFactory({
+      requestData: {},
+      responseType: 'successful',
+      responseData: successfulResponseData,
+      URL,
+    });
+
+    beforeEach(() => {
+      axios.get.mockResolvedValueOnce(requestResponse);
+    });
+
+    it('should return the task data', async () => {
+      const response = await client.tasks.getTask(123456);
+      expect(axios.get).toHaveBeenCalledTimes(1);
+      expect(response).toBe(requestResponse.data);
+    });
+  });
+
+  authenticationErrorTests({
+    requestToExecute: async () => {
+      await client.tasks.getTask(123456);
+    },
+    URL,
+  });
+
+  notFoundTests({
+    requestToExecute: async () => {
+      await client.tasks.getTask(654321);
+    },
+    URL,
+  });
+
+  badResponseCallbackTests({
+    requestToExecute: async () => {
+      await client.tasks.getTask(123456, {});
+    },
+  });
+
+  validResponseCallbackTests({
+    requestToExecute: async () => {
+      const dataCallback = jest
+        .fn()
+        .mockImplementation((data) => ({ newStructure: { ...data } }));
+      const response = await client.tasks.getTask(123456, dataCallback);
+      return [response, dataCallback];
+    },
+    responseData: successfulResponseData,
+    URL,
+  });
+
+  wrongParamsTests({
+    requestToExecute: async () => {
+      await client.tasks.getTask();
+    },
+    URL,
+    paramsList: ['taskId'],
+    positionalParam: true,
+  });
+});


### PR DESCRIPTION
Closes #38

## Get single task info.
This issue is part of the Epic #35

### Objective
Create a module to retrieve task info from the Tickspot API.

### CheckList
- [x] Create a method to get a task.
- [x] Create tests.