### PR TITLE
#44 List projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,76 @@ const result = await client.tasks.getTask(1, callback);
   year: 2020
 }
 ```
+
+### Projects
+
+This module allows you to interact with the Tickspot projects.
+
+#### List All Opened Projects
+
+This method will return all opened projects. This method needs the following params:
+
+- [Required] page parameter for your request.
+
+```javascript
+const result = await client.projects.listOpened(1);
+
+// The result would be something like the following:
+[
+  {
+    id: 16,
+    name: 'Project #1',
+    budget: null,
+    date_closed: null,
+    notifications: false,
+    billable: true,
+    recurring: false,
+    client_id: 987654,
+    owner_id: 123987,
+    url: 'https://secure.tickspot.com/654321/api/v2/projects/16.json',
+    created_at: '2020-04-21T12:35:46.000-04:00',
+    updated_at: '2022-02-14T16:30:15.000-05:00',
+  },
+  {
+    id: 4,
+    name: 'Project #2',
+    budget: null,
+    date_closed: null,
+    notifications: false,
+    billable: true,
+    recurring: false,
+    client_id: 987654,
+    owner_id: 123987,
+    url: 'https://secure.tickspot.com/654321/api/v2/projects/4.json',
+    created_at: '2020-04-21T15:56:06.000-04:00',
+    updated_at: '2022-02-14T13:30:06.000-05:00',
+  },
+]
+
+```
+
+Optionally, You can send a callback to perform an action on the response data. e.g:
+
+```javascript
+const callback = (responseData) => {
+  responseData.map((project) => {
+    return {
+      name: project.name,
+    };
+  });
+};
+
+const result = await client.projects.listOpened(1, callback);
+
+// The result would be something like the following:
+[
+  { name: 'Project #1' },
+  { name: 'Project #2' },
+  { name: 'Project #3' },
+  ...
+]
+```
+
 ## Code of conduct
 
 We welcome everyone to contribute. Make sure you have read the [CODE_OF_CONDUCT][coc] before.

--- a/src/v2/client.js
+++ b/src/v2/client.js
@@ -1,6 +1,7 @@
 import TICK_BASE_URL_START from './constants.js';
 import Entries from './resources/entries.js';
 import Tasks from './resources/tasks.js';
+import Projects from './resources/projects.js';
 
 /**
  * Client module for tickspor v2 API, it is the main class.
@@ -16,5 +17,6 @@ export default class Client {
 
     this.entries = new Entries({ auth: this.auth, baseURL: this.baseURL, agentEmail });
     this.tasks = new Tasks({ auth: this.auth, baseURL: this.baseURL, agentEmail });
+    this.projects = new Projects({ auth: this.auth, baseURL: this.baseURL, agentEmail });
   }
 }

--- a/src/v2/resources/projects.js
+++ b/src/v2/resources/projects.js
@@ -1,0 +1,28 @@
+import BaseResource from '#src/v2/baseResource';
+
+/**
+ * Projects module for tickspot V2 API.
+ */
+
+class Projects extends BaseResource {
+  /**
+   * This method will return all opened projects.
+   * @param {Number} page, the first page returns
+   *     up to 100 records and you can check the next page for more results
+   * @param {callback} responseCallback
+   *    is an optional function to perform a process over the response data.
+   * @return {Array} list of all opened projects.
+   */
+  async listOpened(page, responseCallback) {
+    if (!page) throw new Error('page field is missing');
+
+    const URL = `${this.baseURL}/projects.json`;
+    const params = { page };
+
+    return this.makeRequest({
+      URL, method: 'get', params, responseCallback,
+    });
+  }
+}
+
+export default Projects;

--- a/test/v2/fixture/projects/openedProjectsFixture.js
+++ b/test/v2/fixture/projects/openedProjectsFixture.js
@@ -1,0 +1,32 @@
+const openedProjectsFixture = [
+  {
+    id: 16,
+    name: 'Project #1',
+    budget: null,
+    date_closed: null,
+    notifications: false,
+    billable: true,
+    recurring: false,
+    client_id: 987654,
+    owner_id: 123987,
+    url: 'https://secure.tickspot.com/654321/api/v2/projects/16.json',
+    created_at: '2020-04-21T12:35:46.000-04:00',
+    updated_at: '2022-02-14T16:30:15.000-05:00',
+  },
+  {
+    id: 4,
+    name: 'Project #2',
+    budget: null,
+    date_closed: null,
+    notifications: false,
+    billable: true,
+    recurring: false,
+    client_id: 987654,
+    owner_id: 123987,
+    url: 'https://secure.tickspot.com/654321/api/v2/projects/4.json',
+    created_at: '2020-04-21T15:56:06.000-04:00',
+    updated_at: '2022-02-14T13:30:06.000-05:00',
+  },
+];
+
+export default openedProjectsFixture;

--- a/test/v2/resources/projects/listOpened.test.js
+++ b/test/v2/resources/projects/listOpened.test.js
@@ -1,0 +1,74 @@
+import axios from 'axios';
+import tickspot from '#src/index';
+import responseFactory from '#test/v2/factories/responseFactory';
+import userInfo from '#test/v2/fixture/client';
+import successfulResponseData from '#test/v2/fixture/projects/openedProjectsFixture';
+import authenticationErrorTests from '#test/v2/shared/authentication';
+import {
+  badResponseCallbackTests,
+  validResponseCallbackTests,
+} from '#test/v2/shared/responseCallback';
+import wrongParamsTests from '#test/v2/shared/wrongParams';
+
+jest.mock('axios');
+const client = tickspot({ apiVersion: 2, ...userInfo });
+const URL = `${client.baseURL}/projects.json`;
+
+describe('#listOpened', () => {
+  beforeEach(() => {
+    axios.get.mockClear();
+  });
+
+  describe('when API call is successful', () => {
+    const requestResponse = responseFactory({
+      requestData: {},
+      responseType: 'successful',
+      responseData: successfulResponseData,
+      URL,
+    });
+
+    beforeEach(() => {
+      axios.get.mockResolvedValueOnce(requestResponse);
+    });
+
+    it('should return a list with all opened projects', async () => {
+      const response = await client.projects.listOpened(1);
+      expect(axios.get).toHaveBeenCalledTimes(1);
+      expect(response).toBe(requestResponse.data);
+    });
+  });
+
+  authenticationErrorTests({
+    requestToExecute: async () => {
+      await client.projects.listOpened(1);
+    },
+    URL,
+  });
+
+  badResponseCallbackTests({
+    requestToExecute: async () => {
+      await client.projects.listOpened(1, {});
+    },
+  });
+
+  validResponseCallbackTests({
+    requestToExecute: async () => {
+      const dataCallback = jest
+        .fn()
+        .mockImplementation((data) => ({ newStructure: { ...data } }));
+      const response = await client.projects.listOpened(1, dataCallback);
+      return [response, dataCallback];
+    },
+    responseData: successfulResponseData,
+    URL,
+  });
+
+  wrongParamsTests({
+    requestToExecute: async () => {
+      await client.projects.listOpened();
+    },
+    URL,
+    paramsList: ['page'],
+    positionalParam: true,
+  });
+});


### PR DESCRIPTION
Closes #44 

### Objective
Create a module to retrieve all projects from the Tickspot API.

Documentation: 
- [GET /projects.json](https://github.com/tick/tick-api/blob/master/sections/projects.md).

### CheckList
- [x] Create a method to list all projects.
- [x] Create tests.