### PR TITLE
#58 List project entries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,6 +692,7 @@ const params = {
   startDate: "2021-11-08",
   endDate: "2021-11-09",
 };
+
 const callback = (responseData) =>
   responseData.map((entry) => {
     const date = new Date(entry.date);
@@ -703,6 +704,7 @@ const callback = (responseData) =>
       year: date.getFullYear(),
     };
   });
+
 const result = await client.tasks.listEntries(params, callback);
 // The result would be something like the following:
 [
@@ -782,6 +784,80 @@ const result = await client.projects.listOpened(1, callback);
   { name: 'Project #1' },
   { name: 'Project #2' },
   { name: 'Project #3' },
+  ...
+]
+```
+
+#### List Project Entries
+
+This will return all entries that are related to a specific project and meet the provided parameters. You can send some params to filter the response, those params are the following:
+
+- [Required] startDate. The format is: 'YYYY-MM-DD'.
+- [Required] endDate. The format is: 'YYYY-MM-DD'.
+- [Required] projectId, related parent project.
+- [Optional] userId, will be ignored if the user is not an administrator.
+- [Optional] billable.
+- [Optional] billed.
+
+This method returns a promise with the response data from the tickspot API.
+
+```javascript
+const params = {
+  projectId: 123,
+  startDate: "2021-11-08",
+  endDate: "2021-11-09",
+  billable: true,
+};
+
+const result = await client.projects.listEntries(params);
+// The result would be something like the following:
+[
+  {
+    id: 1,
+    date: "2014-09-17",
+    hours: 2.88,
+    notes: "Example Entry.",
+    task_id: 123,
+    user_id: 4,
+    url: "https://www.tickspot.com/api/v2/123/entries/1.json",
+    created_at: "2021-11-08T15:03:19.000-04:00",
+    updated_at: "2021-11-08T15:03:19.000-04:00"
+  },
+  ...
+]
+```
+
+Optionally, You can send a callback to perform an action on the response data. e.g:
+
+```javascript
+const params = {
+  projectId: 123,
+  startDate: "2021-11-08",
+  endDate: "2021-11-09",
+};
+
+const callback = (responseData) =>
+  responseData.map((entry) => {
+    const date = new Date(entry.date);
+    return {
+      id: entry.id,
+      notes: entry.notes,
+      day: date.getDate(),
+      month: date.getMonth(),
+      year: date.getFullYear(),
+    };
+  });
+
+const result = await client.projects.listEntries(params, callback);
+// The result would be something like the following:
+[
+  {
+    id: 1,
+    notes: 'Example Entry.',
+    day: 08,
+    month: 11,
+    year: 2021
+  }
   ...
 ]
 ```

--- a/src/v2/resources/projects.js
+++ b/src/v2/resources/projects.js
@@ -1,4 +1,5 @@
 import BaseResource from '#src/v2/baseResource';
+import listEntriesHelper from '#src/v2/helpers/listEntriesHelper';
 
 /**
  * Projects module for tickspot V2 API.
@@ -17,6 +18,49 @@ class Projects extends BaseResource {
 
     const URL = `${this.baseURL}/projects.json`;
     const params = { page };
+
+    return this.makeRequest({
+      URL, method: 'get', params, responseCallback,
+    });
+  }
+
+  /**
+   * This method will return all time entries that are related to a project.
+   *
+   * @param {object} Filters contains the params to get the entries.
+   *    [Required] startDate, Format is: 'YYYY-MM-DD'.
+   *    [Required] endDate, Format is: 'YYYY-MM-DD'.
+   *    [Required] projectId, related parent project.
+   *    [Optional] userId, will be ignored if the user is not an administrator.
+   *    [Optional] taskId, related parent task.
+   *    [Optional] billable
+   *    [Optional] billed
+   * @param {function} responseCallback
+   *    is an optional function to perform a process over the response data.
+   *
+   * @returns {object} array with the list of entries or an error if the process fails.
+   */
+  async listEntries({
+    startDate,
+    endDate,
+    projectId,
+    userId,
+    taskId,
+    billable,
+    billed,
+  }, responseCallback) {
+    const { URL, params } = listEntriesHelper({
+      startDate,
+      endDate,
+      userId,
+      projectId,
+      taskId,
+      billable,
+      billed,
+    }, {
+      baseURL: this.baseURL,
+      module: 'projects',
+    });
 
     return this.makeRequest({
       URL, method: 'get', params, responseCallback,

--- a/src/v2/resources/tasks.js
+++ b/src/v2/resources/tasks.js
@@ -127,7 +127,7 @@ class Tasks extends BaseResource {
   }
 
   /**
-   * This method will return all time entries that are related to the task
+   * This method will return all time entries that are related to the task.
    *
    * @param {object} Filters contains the params to get the entries.
    *    [Optional] taskId, related parent task.

--- a/test/v2/resources/projects/listEntries.test.js
+++ b/test/v2/resources/projects/listEntries.test.js
@@ -1,0 +1,80 @@
+import axios from 'axios';
+import tickspot from '#src/index';
+import responseFactory from '#test/v2/factories/responseFactory';
+import userInfo from '#test/v2/fixture/client';
+import successfulResponseData from '#test/v2/fixture/entries/listEntriesResponseData';
+import authenticationErrorTests from '#test/v2/shared/authentication';
+import {
+  badResponseCallbackTests,
+  validResponseCallbackTests,
+} from '#test/v2/shared/responseCallback';
+import wrongParamsTests from '#test/v2/shared/wrongParams';
+
+jest.mock('axios');
+const client = tickspot({ apiVersion: 2, ...userInfo });
+const URL = `${client.baseURL}/projects/123/entries.json`;
+
+describe('#listEntries', () => {
+  const params = {
+    startDate: '2021-11-08',
+    endDate: '2021-11-09',
+    projectId: 123,
+  };
+
+  beforeEach(() => {
+    axios.get.mockClear();
+  });
+
+  describe('when API call is successful', () => {
+    const requestResponse = responseFactory({
+      requestData: {},
+      responseType: 'successful',
+      responseData: successfulResponseData,
+      URL,
+    });
+
+    beforeEach(() => {
+      axios.get.mockResolvedValueOnce(requestResponse);
+    });
+
+    it('should return a list with all entries related to a project', async () => {
+      const response = await client.projects.listEntries(params);
+      expect(axios.get).toHaveBeenCalledTimes(1);
+      expect(response).toBe(requestResponse.data);
+    });
+  });
+
+  authenticationErrorTests({
+    requestToExecute: async () => {
+      await client.projects.listEntries(params);
+    },
+    URL,
+  });
+
+  badResponseCallbackTests({
+    requestToExecute: async () => {
+      await client.projects.listEntries(params, {});
+    },
+  });
+
+  validResponseCallbackTests({
+    requestToExecute: async () => {
+      const dataCallback = jest
+        .fn()
+        .mockImplementation((data) => ({ newStructure: { ...data } }));
+      const response = await client.projects.listEntries(params, dataCallback);
+      return [response, dataCallback];
+    },
+    responseData: successfulResponseData,
+    URL,
+  });
+
+  wrongParamsTests({
+    requestToExecute: async (requestParams) => {
+      await client.projects.listEntries(requestParams);
+    },
+    URL,
+    requestData: params,
+    paramsList: ['startDate', 'endDate', 'projectId'],
+  });
+});


### PR DESCRIPTION
Closed #58

:information_source: This issue is part of the Epic #43.

### Objective
Create a module to retrieve the project entries from the Tickspot API.

Documentation: 
- [GET /projects/16/entries.json](https://github.com/tick/tick-api/blob/master/sections/entries.md#get-entries).

### CheckList
- [x] Create a method to list the project entries.
- [x] Create tests.