### PR TITLE
#46 Add function to get a single project info

### DIFF
--- a/README.md
+++ b/README.md
@@ -862,6 +862,62 @@ const result = await client.projects.listEntries(params, callback);
 ]
 ```
 
+#### Get Project
+
+This method will return the specified project info. This method needs the following params:
+
+- [Required] projectId, project unique identificator.
+
+```javascript
+const result = await client.projects.getProject(16);
+// The result would be something like the following:
+[
+  {
+    id: 16,
+    name: 'Build Death Star',
+    budget: 150.0,
+    date_closed: null,
+    notifications: false,
+    billable: true,
+    recurring: false,
+    client_id: 12,
+    owner_id: 3,
+    url: 'https://www.tickspot.com/api/v2/123/projects/16.json',
+    created_at: '2014-09-09T13:36:20.000-04:00',
+    updated_at: '2014-09-09T13:36:20.000-04:00',
+    total_hours: 22.0,
+    tasks:
+      {
+        count: 1,
+        url: 'https://www.tickspot.com/api/v2/123/projects/16/tasks.json',
+        updated_at: null,
+      },
+    client:
+      {
+        id: 12,
+        name: 'Empire',
+        archive: false,
+        url: 'https://www.tickspot.com/api/v2/123/clients/12.json',
+        updated_at: '2014-09-15T10:32:46.000-04:00',
+      },
+  },
+];
+```
+
+Optionally, You can send a callback to perform an action on the response data. e.g:
+
+```javascript
+const callback = (responseData) => {
+  return {
+    id: responseData.id,
+  };
+};
+
+const result = await client.projects.getProject(16, callback);
+// The result would be something like the following:
+{ id: 16 }
+```
+
 ### Users
 
 This module allows you to interact with the Tickspot users.

--- a/src/v2/resources/projects.js
+++ b/src/v2/resources/projects.js
@@ -66,6 +66,21 @@ class Projects extends BaseResource {
       URL, method: 'get', params, responseCallback,
     });
   }
+
+  /**
+   * This will return specific project info.
+   * @param {Number} projectId, project unique identificator.
+   * @param {function} responseCallback
+   *    is an optional function to perform a process over the response data.
+   *
+   * @returns {object} entry info or an error if the process fails.
+   */
+  async getProject(projectId, responseCallback) {
+    if (!projectId) throw new Error('projectId field is missing');
+
+    const URL = `${this.baseURL}/projects/${projectId}.json`;
+    return this.makeRequest({ URL, method: 'get', responseCallback });
+  }
 }
 
 export default Projects;

--- a/test/v2/fixture/projects/getProjectFixture.js
+++ b/test/v2/fixture/projects/getProjectFixture.js
@@ -1,0 +1,33 @@
+const getProjectFixture = [
+  {
+    id: 16,
+    name: 'Build Death Star',
+    budget: 150.0,
+    date_closed: null,
+    notifications: false,
+    billable: true,
+    recurring: false,
+    client_id: 12,
+    owner_id: 3,
+    url: 'https://www.tickspot.com/api/v2/123/projects/16.json',
+    created_at: '2014-09-09T13:36:20.000-04:00',
+    updated_at: '2014-09-09T13:36:20.000-04:00',
+    total_hours: 22.0,
+    tasks:
+      {
+        count: 1,
+        url: 'https://www.tickspot.com/api/v2/123/projects/16/tasks.json',
+        updated_at: null,
+      },
+    client:
+      {
+        id: 12,
+        name: 'Empire',
+        archive: false,
+        url: 'https://www.tickspot.com/api/v2/123/clients/12.json',
+        updated_at: '2014-09-15T10:32:46.000-04:00',
+      },
+  },
+];
+
+export default getProjectFixture;

--- a/test/v2/resources/projects/getProject.test.js
+++ b/test/v2/resources/projects/getProject.test.js
@@ -1,0 +1,80 @@
+import axios from 'axios';
+import tickspot from '#src/index';
+import responseFactory from '#test/v2/factories/responseFactory';
+import userInfo from '#test/v2/fixture/client';
+import successfulResponseData from '#test/v2/fixture/projects/getProjectFixture';
+import authenticationErrorTests from '#test/v2/shared/authentication';
+import {
+  badResponseCallbackTests,
+  validResponseCallbackTests,
+} from '#test/v2/shared/responseCallback';
+import wrongParamsTests from '#test/v2/shared/wrongParams';
+
+jest.mock('axios');
+const client = tickspot({ apiVersion: 2, ...userInfo });
+const URL = `${client.baseURL}/projects/16.json`;
+
+describe('getProject', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when API call is successful', () => {
+    const requestResponse = responseFactory({
+      requestData: {},
+      responseType: 'successful',
+      responseData: successfulResponseData,
+      URL,
+    });
+
+    beforeEach(() => {
+      axios.get.mockResolvedValueOnce(requestResponse);
+    });
+
+    it('should return the project information', async () => {
+      const response = await client.projects.getProject('16');
+
+      expect(axios.get).toHaveBeenCalledTimes(1);
+      expect(axios.get).toHaveBeenCalledWith(
+        URL,
+        { headers: client.projects.DEFAULT_HEADERS },
+      );
+
+      expect(response).toEqual(requestResponse.data);
+    });
+  });
+
+  authenticationErrorTests({
+    requestToExecute: async () => {
+      await client.projects.getProject('16');
+    },
+    URL,
+  });
+
+  badResponseCallbackTests({
+    requestToExecute: async () => {
+      await client.projects.getProject('16', {});
+    },
+  });
+
+  validResponseCallbackTests({
+    requestToExecute: async () => {
+      const dataCallback = jest
+        .fn()
+        .mockImplementation((data) => ({ newStructure: { ...data } }));
+      const response = await client.projects.getProject('16', dataCallback);
+      return [response, dataCallback];
+    },
+    responseData: successfulResponseData,
+    URL,
+  });
+
+  wrongParamsTests({
+    requestToExecute: async () => {
+      await client.projects.getProject();
+    },
+    URL,
+    paramsList: ['projectId'],
+    positionalParam: true,
+  });
+});


### PR DESCRIPTION
closes #46 

:information_source: This issue is part of the Epic #43.

### Objective
Create a module to retrieve project info from the Tickspot API.

Documentation: 
- [GET /projects/16.json](https://github.com/tick/tick-api/blob/master/sections/projects.md#get-project).

### CheckList
- [x] Create a method to get a task.
- [x] Create tests.