### PR TITLE
#47 Create project

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,6 +723,76 @@ const result = await client.tasks.listEntries(params, callback);
 
 This module allows you to interact with the Tickspot projects.
 
+#### Create Project
+
+This method will create a new project from the parameters passed. No tasks will be created. Time entries will not be allowed until at least one task is created. It is strictly limited to administrators
+
+This method will return the new project info. This method needs the following params:
+
+- [Required] name, name of the project
+- [Required] clientId, related to the client
+- [Required] ownerId, owner of the project
+- [Optional] budget.
+- [Optional] notifications.
+- [Optional] billable.
+- [Optional] recurring.
+
+```javascript
+const data = {
+  name: 'test #1',
+  clientId: 123456,
+  ownerId: 654321,
+  budget: 50.0,
+  notifications: false,
+  billable: false,
+  recurring: false,
+};
+
+const result = await client.projects.create(data);
+
+// The result would be something like the following:
+{
+  id: 123,
+  name: 'test #1',
+  budget: 50,
+  date_closed: null,
+  notifications: false,
+  billable: false,
+  recurring: false,
+  client_id: 365968,
+  owner_id: 337683,
+  url: 'https://secure.tickspot.com/654321/api/v2/projects/123.json',
+  created_at: '2022-03-08T17:29:02.000-05:00',
+  updated_at: '2022-03-08T17:29:02.000-05:00'
+}
+```
+
+Optionally, You can send a callback to perform an action on the response data. e.g:
+
+```javascript
+const callback = (responseData) => {
+  return {
+    name: responseData.name,
+    budget: responseData.budget
+  };
+};
+
+const data = {
+  name: 'test #1',
+  clientId: 123456,
+  ownerId: 654321,
+  budget: 50.0,
+  notifications: false,
+  billable: false,
+  recurring: false,
+};
+
+const result = await client.projects.create(data, callback);
+
+// The result would be something like the following:
+{ name: 'test #1', budget: 50 }
+```
+
 #### List All Opened Projects
 
 This method will return all opened projects. This method needs the following params:

--- a/src/v2/resources/projects.js
+++ b/src/v2/resources/projects.js
@@ -6,6 +6,53 @@ import listEntriesHelper from '#src/v2/helpers/listEntriesHelper';
  */
 class Projects extends BaseResource {
   /**
+   * This method will create a new project, it is strictly limited to administrators,
+   * no tasks will be created, time entries will not be allowed until at least one
+   * task is created.
+   * @param {object} Task contains the params to create the task.
+   *    [Required] name
+   *    [Required] client_id
+   *    [Required] owner_id
+   *    [Optional] budget
+   *    [Optional] notifications
+   *    [Optional] billable
+   *    [Optional] recurring
+
+   * @param {callback} responseCallback
+   *    is an optional function to perform a process over the response data.
+   *
+   * @return {Object} a object with created project data.
+   */
+  async create({
+    name,
+    clientId,
+    ownerId,
+    budget,
+    notifications,
+    billable,
+    recurring,
+  }, responseCallback) {
+    if (!name) throw new Error('name field is missing');
+    if (!clientId) throw new Error('clientId field is missing');
+    if (!ownerId) throw new Error('ownerId field is missing');
+
+    const body = {
+      name,
+      budget,
+      ...(clientId && { client_id: clientId }),
+      ...(ownerId && { owner_id: ownerId }),
+      ...(typeof notifications === 'boolean' && { notifications }),
+      ...(typeof billable === 'boolean' && { billable }),
+      ...(typeof recurring === 'boolean' && { recurring }),
+    };
+
+    const URL = `${this.baseURL}/projects.json`;
+    return this.makeRequest({
+      URL, method: 'post', body, responseCallback,
+    });
+  }
+
+  /**
    * This method will return all opened projects.
    * @param {Number} page, the first page returns
    *     up to 100 records and you can check the next page for more results

--- a/test/v2/fixture/projects/createProjectFixture.js
+++ b/test/v2/fixture/projects/createProjectFixture.js
@@ -1,0 +1,18 @@
+const createProjectFixture = {
+  data: {
+    id: 123456,
+    name: 'test #1',
+    budget: 50,
+    date_closed: null,
+    notifications: false,
+    billable: false,
+    recurring: false,
+    client_id: 654321,
+    owner_id: 987654,
+    url: 'https://secure.tickspot.com/114217/api/v2/projects/123456.json',
+    created_at: '2022-03-08T17:29:02.000-05:00',
+    updated_at: '2022-03-08T17:29:02.000-05:00',
+  },
+};
+
+export default createProjectFixture;

--- a/test/v2/resources/projects/createProject.test.js
+++ b/test/v2/resources/projects/createProject.test.js
@@ -1,0 +1,87 @@
+import axios from 'axios';
+import tickspot from '#src/index';
+import responseFactory from '#test/v2/factories/responseFactory';
+import userInfo from '#test/v2/fixture/client';
+import successfulResponseData from '#test/v2/fixture/projects/createProjectFixture.js';
+import authenticationErrorTests from '#test/v2/shared/authentication';
+import {
+  badResponseCallbackTests,
+  validResponseCallbackTests,
+} from '#test/v2/shared/responseCallback';
+import wrongParamsTests from '#test/v2/shared/wrongParams';
+
+jest.mock('axios');
+const client = tickspot({ apiVersion: 2, ...userInfo });
+const URL = `${client.baseURL}/projects.json`;
+
+describe('createProject', () => {
+  const projectData = {
+    name: 'test #1',
+    clientId: 654321,
+    ownerId: 987654,
+    budget: 50.0,
+    notifications: false,
+    billable: false,
+    recurring: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when API call is successful', () => {
+    const requestResponse = responseFactory({
+      requestData: projectData,
+      responseType: 'created',
+      responseData: successfulResponseData,
+      URL,
+    });
+
+    beforeEach(() => {
+      axios.post.mockResolvedValueOnce(requestResponse);
+    });
+
+    it('should create the new project', async () => {
+      const response = await client.projects.create(projectData);
+      expect(response.data.name).toBe(projectData.name);
+    });
+  });
+
+  authenticationErrorTests({
+    requestToExecute: async () => {
+      await client.projects.create(projectData);
+    },
+    URL,
+    method: 'post',
+  });
+
+  badResponseCallbackTests({
+    requestToExecute: async () => {
+      await client.projects.create(projectData, {});
+    },
+    method: 'post',
+  });
+
+  validResponseCallbackTests({
+    requestToExecute: async () => {
+      const dataCallback = jest
+        .fn()
+        .mockImplementation((data) => ({ newStructure: { ...data } }));
+      const response = await client.projects.create(projectData, dataCallback);
+      return [response, dataCallback];
+    },
+    responseData: successfulResponseData,
+    method: 'post',
+    URL,
+  });
+
+  wrongParamsTests({
+    requestToExecute: async (requestParams) => {
+      await client.projects.create(requestParams);
+    },
+    URL,
+    method: 'post',
+    requestData: projectData,
+    paramsList: ['name', 'clientId', 'ownerId'],
+  });
+});


### PR DESCRIPTION
Closes #47 
### Objective
Create a module to create projects from the Tickspot API.

Documentation:
- [POST /projects.json](https://github.com/tick/tick-api/blob/master/sections/projects.md#create-project).

### CheckList
- [x] Create a method to create projects.
- [x] Create tests.