### PR TITLE
#55 List project tasks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1135,6 +1135,55 @@ const result = await client.projects.getProject(16, callback);
 { id: 16 }
 ```
 
+#### List Project Tasks
+
+This method will return all opened tasks for the project. This method needs the following params:
+
+- [Required] projectId, project unique identificator.
+
+```javascript
+const result = await client.projects.listOpenedTasks(16);
+// The result would be something like the following:
+[
+  {
+    id: 123456,
+    name: 'Task #1',
+    budget: null,
+    position: 1,
+    project_id: 16,
+    date_closed: null,
+    billable: false,
+    url: 'https://secure.tickspot.com/16/api/v2/tasks/123456.json',
+    created_at: '2020-04-21T16:06:53.000-04:00',
+    updated_at: '2022-01-17T17:51:25.000-05:00'
+  },
+  {
+
+  },
+  ...
+]
+````
+
+Optionally, You can send a callback to perform an action on the response data. e.g:
+
+```javascript
+const callback = (responseData) => {
+  responseData.map((task) => {
+    return {
+      id: task.id,
+      name: task.name,
+    };
+  });
+};
+
+const result = await client.projects.listOpenedTasks(16, callback);
+// The result would be something like the following:
+[
+  { id: 123456, name: 'Task #1' },
+  { id: 654321, name: 'Task #2' },
+  ...
+]
+```
 ### Users
 
 This module allows you to interact with the Tickspot users.

--- a/src/v2/resources/projects.js
+++ b/src/v2/resources/projects.js
@@ -206,6 +206,21 @@ class Projects extends BaseResource {
     const URL = `${this.baseURL}/projects/${projectId}.json`;
     return this.makeRequest({ URL, method: 'get', responseCallback });
   }
+
+  /**
+   * This will return all opened tasks for the project
+   * @param {Number} projectId, project unique identificator.
+   * @param {function} responseCallback
+   *    is an optional function to perform a process over the response data.
+   *
+   * @returns {object} project info or an error if the process fails.
+   */
+  async listOpenedTasks(projectId, responseCallback) {
+    if (!projectId) throw new Error('projectId field is missing');
+
+    const URL = `${this.baseURL}/projects/${projectId}/tasks.json`;
+    return this.makeRequest({ URL, method: 'get', responseCallback });
+  }
 }
 
 export default Projects;

--- a/test/v2/resources/projects/listOpenedTasks.test.js
+++ b/test/v2/resources/projects/listOpenedTasks.test.js
@@ -1,0 +1,74 @@
+import axios from 'axios';
+import tickspot from '#src/index';
+import responseFactory from '#test/v2/factories/responseFactory';
+import userInfo from '#test/v2/fixture/client';
+import successfulResponseData from '#test/v2/fixture/tasks/openedTasksFixture';
+import authenticationErrorTests from '#test/v2/shared/authentication';
+import {
+  badResponseCallbackTests,
+  validResponseCallbackTests,
+} from '#test/v2/shared/responseCallback';
+import wrongParamsTests from '#test/v2/shared/wrongParams';
+
+jest.mock('axios');
+const client = tickspot({ apiVersion: 2, ...userInfo });
+const URL = `${client.baseURL}/projects/123/tasks.json`;
+
+describe('#listOpenedTasks', () => {
+  beforeEach(() => {
+    axios.get.mockClear();
+  });
+
+  describe('when API call is successful', () => {
+    const requestResponse = responseFactory({
+      requestData: {},
+      responseType: 'successful',
+      responseData: successfulResponseData,
+      URL,
+    });
+
+    beforeEach(() => {
+      axios.get.mockResolvedValueOnce(requestResponse);
+    });
+
+    it('should return all opened tasks for the project', async () => {
+      const response = await client.projects.listOpenedTasks(123);
+      expect(axios.get).toHaveBeenCalledTimes(1);
+      expect(response).toBe(requestResponse.data);
+    });
+  });
+
+  authenticationErrorTests({
+    requestToExecute: async () => {
+      await client.projects.listOpenedTasks(123);
+    },
+    URL,
+  });
+
+  badResponseCallbackTests({
+    requestToExecute: async () => {
+      await client.projects.listOpenedTasks(123, {});
+    },
+  });
+
+  validResponseCallbackTests({
+    requestToExecute: async () => {
+      const dataCallback = jest
+        .fn()
+        .mockImplementation((data) => ({ newStructure: { ...data } }));
+      const response = await client.projects.listOpenedTasks(123, dataCallback);
+      return [response, dataCallback];
+    },
+    responseData: successfulResponseData,
+    URL,
+  });
+
+  wrongParamsTests({
+    requestToExecute: async () => {
+      await client.projects.listOpenedTasks();
+    },
+    URL,
+    paramsList: ['projectId'],
+    positionalParam: true,
+  });
+});


### PR DESCRIPTION
Closes #55 
### Objective
Create a module to retrieve the project tasks from the Tickspot API.

Documentation: 
- [GET /projects/16/tasks.json](https://github.com/tick/tick-api/blob/master/sections/tasks.md#get-tasks).

### CheckList
- [x] Create a method to list the project tasks.
- [x] Create tests.