### PR TITLE
#51 Get single client info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1412,6 +1412,48 @@ const result = await client.users.listEntries(params, callback);
 ]
 ```
 
+### Clients
+
+This module allows you to interact with the Tickspot clients.
+
+#### Get Client
+
+This will return the specified client along with a summary of project information. This method needs the following params:
+
+- [Required] clientId, client unique identificator.
+
+```javascript
+const result = await client.clients.getClient(123);
+// The result would be something like the following:
+{
+  id: 123,
+  name: 'Client #1',
+  archive: false,
+  url: 'https://secure.tickspot.com/654321/api/v2/clients/123.json',
+  updated_at: '2022-03-26T19:47:12.000-04:00',
+  projects: {
+    count: 9,
+    url: 'https://secure.tickspot.com/654321/api/v2/clients/123/projects.json',
+    updated_at: '2022-03-26T19:47:12.000-04:00'
+  }
+}
+```
+
+Optionally, You can send a callback to perform an action on the response data. e.g:
+
+```javascript
+const callback = (responseData) => {
+  return {
+    id: responseData.id,
+  };
+};
+
+const result = await client.clients.getClient(123, callback);
+// The result would be something like the following:
+{ id: 123, name: 'Client #1' }
+```
+
+
 ## Code of conduct
 
 We welcome everyone to contribute. Make sure you have read the [CODE_OF_CONDUCT][coc] before.

--- a/src/v2/client.js
+++ b/src/v2/client.js
@@ -3,6 +3,7 @@ import Entries from './resources/entries.js';
 import Tasks from './resources/tasks.js';
 import Projects from './resources/projects.js';
 import Users from './resources/users.js';
+import Clients from './resources/clients.js';
 
 /**
  * Client module for tickspor v2 API, it is the main class.
@@ -20,5 +21,6 @@ export default class Client {
     this.tasks = new Tasks({ auth: this.auth, baseURL: this.baseURL, agentEmail });
     this.projects = new Projects({ auth: this.auth, baseURL: this.baseURL, agentEmail });
     this.users = new Users({ auth: this.auth, baseURL: this.baseURL, agentEmail });
+    this.clients = new Clients({ auth: this.auth, baseURL: this.baseURL, agentEmail });
   }
 }

--- a/src/v2/resources/clients.js
+++ b/src/v2/resources/clients.js
@@ -1,0 +1,23 @@
+import BaseResource from '#src/v2/baseResource';
+
+/**
+ * Clients module for tickspot V2 API.
+ */
+class Clients extends BaseResource {
+  /**
+   * This will return the specified client along with a summary of project information.
+   * @param {Number} clientId, client unique identificator.
+   * @param {function} responseCallback
+   *    is an optional function to perform a process over the response data.
+   *
+   * @returns {object} client info or an error if the process fails.
+   */
+  async getClient(clientId, responseCallback) {
+    if (!clientId) throw new Error('clientId field is missing');
+
+    const URL = `${this.baseURL}/clients/${clientId}.json`;
+    return this.makeRequest({ URL, method: 'get', responseCallback });
+  }
+}
+
+export default Clients;

--- a/test/v2/fixture/clients/getClientFixture.js
+++ b/test/v2/fixture/clients/getClientFixture.js
@@ -1,0 +1,14 @@
+const getClientFixture = {
+  id: 123456,
+  name: 'Client #1',
+  archive: false,
+  url: 'https://secure.tickspot.com/654321/api/v2/clients/123456.json',
+  updated_at: '2022-03-25T12:11:03.000-04:00',
+  projects: {
+    count: 2,
+    url: 'https://secure.tickspot.com/654321/api/v2/clients/123456/projects.json',
+    updated_at: '2022-03-25T12:11:03.000-04:00',
+  },
+};
+
+export default getClientFixture;

--- a/test/v2/resources/clients/getClient.test.js
+++ b/test/v2/resources/clients/getClient.test.js
@@ -1,0 +1,75 @@
+import axios from 'axios';
+import tickspot from '#src/index';
+import responseFactory from '#test/v2/factories/responseFactory';
+import userInfo from '#test/v2/fixture/client';
+import successfulResponseData from '#test/v2/fixture/clients/getClientFixture';
+import authenticationErrorTests from '#test/v2/shared/authentication';
+import {
+  badResponseCallbackTests,
+  validResponseCallbackTests,
+} from '#test/v2/shared/responseCallback';
+import wrongParamsTests from '#test/v2/shared/wrongParams';
+
+jest.mock('axios');
+const client = tickspot({ apiVersion: 2, ...userInfo });
+const URL = `${client.baseURL}/clients/123456.json`;
+
+describe('getClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when API call is successful', () => {
+    const requestResponse = responseFactory({
+      requestData: {},
+      responseType: 'successful',
+      responseData: successfulResponseData,
+      URL,
+    });
+
+    beforeEach(() => {
+      axios.get.mockResolvedValueOnce(requestResponse);
+    });
+
+    it('should return the client information', async () => {
+      const response = await client.clients.getClient(123456);
+
+      expect(axios.get).toHaveBeenCalledTimes(1);
+      expect(response).toEqual(requestResponse.data);
+    });
+  });
+
+  authenticationErrorTests({
+    requestToExecute: async () => {
+      await client.clients.getClient(123456);
+    },
+    URL,
+  });
+
+  badResponseCallbackTests({
+    requestToExecute: async () => {
+      await client.clients.getClient(123456, {});
+    },
+  });
+
+  validResponseCallbackTests({
+    requestToExecute: async () => {
+      const dataCallback = jest
+        .fn()
+        .mockImplementation((data) => ({ newStructure: { ...data } }));
+      const response = await client.clients.getClient(123456, dataCallback);
+      return [response, dataCallback];
+    },
+    responseData: successfulResponseData,
+    URL,
+  });
+
+  wrongParamsTests({
+    requestToExecute: async () => {
+      await client.clients.getClient();
+    },
+    URL,
+    paramsList: ['clientId'],
+    positionalParam: true,
+  });
+});


### PR DESCRIPTION
Closes #51 
## Get single client info.
This issue is part of the Epic #48 

### Objective
Create a module to retrieve client info from the Tickspot API.

### CheckList
- [x] Create a method to get a client.
- [x] Create tests.