### PR TITLE
#56 Delete client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1502,6 +1502,18 @@ const result = await client.clients.getClient(123, callback);
 { id: 123, name: 'Client #1' }
 ```
 
+#### Delete Client
+
+This method will delete a specific client. Only clients without any projects can be deleted. The params you can send are the following:
+
+- [Required] clientId, the client unique identificator.
+
+```javascript
+const result = await client.clients.delete(123456);
+
+// The result will be true if the client was deleted
+```
+
 ## Code of conduct
 
 We welcome everyone to contribute. Make sure you have read the [CODE_OF_CONDUCT][coc] before.

--- a/src/v2/resources/clients.js
+++ b/src/v2/resources/clients.js
@@ -37,6 +37,19 @@ class Clients extends BaseResource {
     const URL = `${this.baseURL}/clients/${clientId}.json`;
     return this.makeRequest({ URL, method: 'get', responseCallback });
   }
+
+  /**
+   * This will will delete the client.
+   * @param {Number} clientId, client unique identificator. Only clients without any
+      projects can be deleted
+   * @returns {Boolean} true if the cliente was deleted or an error if the process fails.
+   */
+  async delete(clientId) {
+    if (!clientId) throw new Error('clientId field is missing');
+
+    const URL = `${this.baseURL}/clients/${clientId}.json`;
+    return this.makeRequest({ URL, method: 'delete' });
+  }
 }
 
 export default Clients;

--- a/test/v2/factories/responseFactory.js
+++ b/test/v2/factories/responseFactory.js
@@ -39,6 +39,12 @@ const responseFactory = ({
             method, requestData, messageTimeMissed, auth),
       };
 
+    case 'notAcceptable':
+      return {
+        response: responseGenerator(URL, 406, 'Not Acceptable',
+          method, requestData, responseData, auth),
+      };
+
     default:
       throw new Error('responseType is missing');
   }

--- a/test/v2/fixture/shared/responseData.js
+++ b/test/v2/fixture/shared/responseData.js
@@ -19,4 +19,13 @@ export const noContentResponse = {
   },
 };
 
-export default { notFoundResponse, unprocessableEntityResponse, noContentResponse };
+export const notAcceptable = {
+  data: {
+    status: 406,
+    statusText: 'Not Acceptable',
+  },
+};
+
+export default {
+  notFoundResponse, unprocessableEntityResponse, noContentResponse, notAcceptable,
+};

--- a/test/v2/resources/clients/deleteClient.test.js
+++ b/test/v2/resources/clients/deleteClient.test.js
@@ -1,0 +1,72 @@
+import axios from 'axios';
+import tickspot from '#src/index';
+import responseFactory from '#test/v2/factories/responseFactory';
+import userInfo from '#test/v2/fixture/client';
+import { noContentResponse } from '#test/v2/fixture/shared/responseData';
+import authenticationErrorTests from '#test/v2/shared/authentication';
+import notFoundTests from '#test/v2/shared/notFound';
+import wrongParamsTests from '#test/v2/shared/wrongParams';
+import notAcceptableTest from '#test/v2/shared/notAcceptable';
+
+jest.mock('axios');
+const client = tickspot({ apiVersion: 2, ...userInfo });
+const URL = `${client.baseURL}/clients/123456.json`;
+
+describe('#delete', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when API call is successful', () => {
+    const requestResponse = responseFactory({
+      requestData: {},
+      responseType: 'successfulNoContent',
+      responseData: noContentResponse,
+      URL,
+    });
+
+    beforeEach(() => {
+      axios.delete.mockResolvedValueOnce(requestResponse);
+    });
+
+    it('should return true', async () => {
+      const response = await client.clients.delete(123456);
+
+      expect(axios.delete).toHaveBeenCalledTimes(1);
+      expect(response).toEqual(true);
+    });
+  });
+
+  authenticationErrorTests({
+    requestToExecute: async () => {
+      await client.clients.delete(123456);
+    },
+    URL,
+    method: 'delete',
+  });
+
+  notFoundTests({
+    requestToExecute: async () => {
+      await client.clients.delete(654321);
+    },
+    URL,
+    method: 'delete',
+  });
+
+  wrongParamsTests({
+    requestToExecute: async () => {
+      await client.clients.delete();
+    },
+    URL,
+    paramsList: ['clientId'],
+    positionalParam: true,
+  });
+
+  notAcceptableTest({
+    requestToExecute: async () => {
+      await client.clients.delete(123456);
+    },
+    URL,
+    method: 'delete',
+  });
+});

--- a/test/v2/shared/notAcceptable.js
+++ b/test/v2/shared/notAcceptable.js
@@ -1,0 +1,40 @@
+import responseFactory from '#test/v2/factories/responseFactory';
+import { notAcceptable } from '#test/v2/fixture/shared/responseData';
+import { mockRejectedValueOnce, shouldHaveBeenCalledTimes } from './utils/axios';
+
+/**
+ * This will generate a test when a resource is not acceptable.
+ *
+ * @param {String} URL endpoint to generate the mock response.
+ * @param {String} method HTTP method.
+ * @param {callback} requestToExecute
+ *    receives a function that will execute the request that will throw the error.
+ */
+
+const notAcceptableTest = ({
+  URL, method = 'get', requestToExecute,
+}) => {
+  describe('when the API call is not acceptable', () => {
+    const responseData = responseFactory({
+      requestData: {},
+      responseType: 'notAcceptable',
+      responseData: notAcceptable,
+      URL,
+    });
+
+    beforeEach(() => {
+      mockRejectedValueOnce({ method, responseData });
+    });
+
+    it('an error should be thrown when making the call', async () => {
+      try {
+        await requestToExecute();
+      } catch (error) {
+        shouldHaveBeenCalledTimes({ method, times: 1 });
+        expect(error).toEqual(new Error('Request Error: 406'));
+      }
+    });
+  });
+};
+
+export default notAcceptableTest;


### PR DESCRIPTION
Closes #56 

## Delete client.
This issue is part of the Epic #48 

### Objective
Create a module to delete a client from the Tickspot API.

### CheckList
- [x] Create a method to delete a client.
- [x] Create tests.