### PR TITLE
#53 Create client function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1418,6 +1418,53 @@ const result = await client.users.listEntries(params, callback);
 
 This module allows you to interact with the Tickspot clients.
 
+#### Create Client
+
+This method will create a new client from the parameters passed. It is strictly limited to administrators.
+
+This method will return the new client info. This method needs the following params:
+
+- [Required] name, name of the client
+- [Optional] archive
+
+```javascript
+const data = {
+  name: 'test #1',
+  archive: false,
+};
+
+const result = await client.clients.create(data);
+
+// The result would be something like the following:
+{
+  id: 123,
+  name: 'test #1',
+  archive: false,
+  updated_at: '2022-03-08T17:29:02.000-05:00'
+}
+```
+
+Optionally, You can send a callback to perform an action on the response data. e.g:
+
+```javascript
+const callback = (responseData) => {
+  return {
+    name: responseData.name,
+    archive: responseData.archive
+  };
+};
+
+const data = {
+  name: 'test #1',
+  archive: false,
+};
+
+const result = await client.clients.create(data, callback);
+
+// The result would be something like the following:
+{ name: 'test #1', archive: false }
+```
+
 #### List All Clients
 
 This method will return all the clients that have opened projects. This method needs the following params:

--- a/src/v2/resources/clients.js
+++ b/src/v2/resources/clients.js
@@ -5,6 +5,34 @@ import BaseResource from '#src/v2/baseResource';
  */
 class Clients extends BaseResource {
   /**
+   * This method will create a new client, it is strictly limited to administrators.
+   * @param {object} Client contains the params to create the client.
+   *    [Required] name
+   *    [Optional] archive
+
+   * @param {callback} responseCallback
+   *    is an optional function to perform a process over the response data.
+   *
+   * @return {Object} a object with created client data.
+   */
+  async create({
+    name,
+    archive,
+  }, responseCallback) {
+    if (!name) throw new Error('name field is missing');
+
+    const body = {
+      name,
+      ...(typeof archive === 'boolean' && { archive }),
+    };
+
+    const URL = `${this.baseURL}/clients.json`;
+    return this.makeRequest({
+      URL, method: 'post', body, responseCallback,
+    });
+  }
+
+  /**
    * This method will return all the clients that have opened projects.
    * @param {Number} page, the first page returns
    *     up to 100 records and you can check the next page for more results

--- a/test/v2/fixture/clients/createClientFixture.js
+++ b/test/v2/fixture/clients/createClientFixture.js
@@ -1,0 +1,11 @@
+const createClientFixture = {
+  data: {
+    id: 1234,
+    name: 'Test',
+    archive: false,
+    url: 'https://secure.tickspot.com/114217/api/v2/clients/430754.json',
+    updated_at: '2022-04-10T11:59:52.000-04:00',
+  },
+};
+
+export default createClientFixture;

--- a/test/v2/fixture/clients/createClientFixture.js
+++ b/test/v2/fixture/clients/createClientFixture.js
@@ -3,7 +3,7 @@ const createClientFixture = {
     id: 1234,
     name: 'Test',
     archive: false,
-    url: 'https://secure.tickspot.com/114217/api/v2/clients/430754.json',
+    url: 'https://secure.tickspot.com/114217/api/v2/clients/1234.json',
     updated_at: '2022-04-10T11:59:52.000-04:00',
   },
 };

--- a/test/v2/resources/clients/createClient.test.js
+++ b/test/v2/resources/clients/createClient.test.js
@@ -1,0 +1,82 @@
+import axios from 'axios';
+import tickspot from '#src/index';
+import responseFactory from '#test/v2/factories/responseFactory';
+import userInfo from '#test/v2/fixture/client';
+import successfulResponseData from '#test/v2/fixture/clients/createClientFixture.js';
+import authenticationErrorTests from '#test/v2/shared/authentication';
+import {
+  badResponseCallbackTests,
+  validResponseCallbackTests,
+} from '#test/v2/shared/responseCallback';
+import wrongParamsTests from '#test/v2/shared/wrongParams';
+
+jest.mock('axios');
+const client = tickspot({ apiVersion: 2, ...userInfo });
+const URL = `${client.baseURL}/clients.json`;
+
+describe('#create', () => {
+  const clientData = {
+    name: 'Test',
+    archive: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when API call is successful', () => {
+    const requestResponse = responseFactory({
+      requestData: clientData,
+      responseType: 'created',
+      responseData: successfulResponseData,
+      URL,
+    });
+
+    beforeEach(() => {
+      axios.post.mockResolvedValueOnce(requestResponse);
+    });
+
+    it('should create the new client', async () => {
+      const response = await client.clients.create(clientData);
+      expect(response.data.name).toBe(clientData.name);
+    });
+  });
+
+  authenticationErrorTests({
+    requestToExecute: async () => {
+      await client.clients.create(clientData);
+    },
+    URL,
+    method: 'post',
+  });
+
+  badResponseCallbackTests({
+    requestToExecute: async () => {
+      await client.clients.create(clientData, {});
+    },
+    method: 'post',
+  });
+
+  validResponseCallbackTests({
+    requestToExecute: async () => {
+      const dataCallback = jest
+        .fn()
+        .mockImplementation((data) => ({ newStructure: { ...data } }));
+      const response = await client.clients.create(clientData, dataCallback);
+      return [response, dataCallback];
+    },
+    responseData: successfulResponseData,
+    method: 'post',
+    URL,
+  });
+
+  wrongParamsTests({
+    requestToExecute: async (requestParams) => {
+      await client.clients.create(requestParams);
+    },
+    URL,
+    method: 'post',
+    requestData: clientData,
+    paramsList: ['name'],
+  });
+});


### PR DESCRIPTION
Closes #53 
 
## List tasks.
This issue is part of the Epic #48 

### Objective
Create a module to create client from the Tickspot API.

### CheckList
- [x] Create a method to create client.
- [x] Create tests.