### PR TITLE
(#20) Change how the lib is instanciated

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,20 @@ npm i tickspot.js
 
 ## Usage
 
-To use tickspot.js client, just import the tickspot module as following:
+To use tickspot.js client, just import the Tickspot module as following:
 
 ```javascript
-import tickspot from "tickspot.js";
+import Tickspot from "tickspot.js";
 ```
 
-Once the module is imported, create an instance using the `tickspot` function. This function will require the following data:
+Once the module is imported, create an instance using the `init` function. This function will require the following data:
 
 - `apiVersion` - This is version of the Tick API.
 - `subscriptionId` and `apiToken` - Those are unique data that you will find in your Tickspot profile.
 - `agentEmail` - Your email.
 
 ```javascript
-const client = tickspot({
+const tickspot = Tickspot.init({
   apiVersion: 2,
   subscriptionId: "subscriptionId",
   apiToken: "apiToken",

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -15,7 +15,7 @@ This method will return all the clients that have opened projects. This method n
 - [Required] page, parameter for your request.
 
 ```javascript
-const result = await client.clients.list(1);
+const result = await tickspot.clients.list(1);
 // The result would be something like the following:
 [
   {
@@ -45,7 +45,7 @@ const callback = (responseData) => {
     };
   });
 };
-const result = await client.clients.list(1, callback);
+const result = await tickspot.clients.list(1, callback);
 // The result would be something like the following:
 [
   { name: 'Client #1' },
@@ -62,7 +62,7 @@ This will return the specified client along with a summary of project informatio
 - [Required] clientId, client unique identificator.
 
 ```javascript
-const result = await client.clients.getClient(123);
+const result = await tickspot.clients.getClient(123);
 // The result would be something like the following:
 {
   id: 123,
@@ -87,7 +87,7 @@ const callback = (responseData) => {
   };
 };
 
-const result = await client.clients.getClient(123, callback);
+const result = await tickspot.clients.getClient(123, callback);
 // The result would be something like the following:
 { id: 123, name: 'Client #1' }
 ```
@@ -107,7 +107,7 @@ const data = {
   archive: false,
 };
 
-const result = await client.clients.create(data);
+const result = await tickspot.clients.create(data);
 
 // The result would be something like the following:
 {
@@ -133,7 +133,7 @@ const data = {
   archive: false,
 };
 
-const result = await client.clients.create(data, callback);
+const result = await tickspot.clients.create(data, callback);
 
 // The result would be something like the following:
 { name: 'test #1', archive: false }
@@ -154,7 +154,7 @@ const data = {
   archive: false,
 };
 
-const result = await client.clients.update(data);
+const result = await tickspot.clients.update(data);
 // The result would be something like the following:
 {
   id: 123456,
@@ -180,7 +180,7 @@ const data = {
   archive: false,
 };
 
-const result = await client.clients.update(data, callback);
+const result = await tickspot.clients.update(data, callback);
 // The result would be something like the following:
 {
   name: "Client #1";
@@ -189,12 +189,12 @@ const result = await client.clients.update(data, callback);
 
 ## Delete Client
 
-This method will delete a specific client. Only clients without any projects can be deleted. The params you can send are the following:
+This method will delete a specific tickspot. Only clients without any projects can be deleted. The params you can send are the following:
 
 - [Required] clientId, the client unique identificator.
 
 ```javascript
-const result = await client.clients.delete(123456);
+const result = await tickspot.clients.delete(123456);
 
 // The result will be true if the client was deleted
 ```

--- a/docs/entries.md
+++ b/docs/entries.md
@@ -29,7 +29,7 @@ const params = {
   billable: true,
 };
 
-const result = await client.entries.list(params);
+const result = await tickspot.entries.list(params);
 
 // The result would be something like the following:
 [
@@ -68,7 +68,7 @@ const callback = (responseData) =>
     };
   });
 
-const result = await client.entries.list(params, callback);
+const result = await tickspot.entries.list(params, callback);
 // The result would be something like the following:
 [
   {
@@ -89,7 +89,7 @@ This will return the specified entry info. This method needs the following param
 - [Required] entryId, entry unique identificator.
 
 ```javascript
-const result = await client.entries.getEntry(1);
+const result = await tickspot.entries.getEntry(1);
 
 // The result would be something like the following:
 {
@@ -132,7 +132,7 @@ const callback = (responseData) => {
   };
 };
 
-const result = await client.entries.getEntry(1, callback);
+const result = await tickspot.entries.getEntry(1, callback);
 
 // The result would be something like the following:
 {
@@ -165,7 +165,7 @@ const data = {
   taskId: 12345678,
 };
 
-const result = await client.entries.create(data);
+const result = await tickspot.entries.create(data);
 
 // The result would be something like the following:
 {
@@ -200,7 +200,7 @@ const callback = (responseData) => {
   };
 };
 
-const result = await client.entries.create(data, callback);
+const result = await tickspot.entries.create(data, callback);
 
 // The result would be something like the following:
 {
@@ -236,7 +236,7 @@ const data = {
   billed: true,
 };
 
-const result = await client.entries.updateEntry(data);
+const result = await tickspot.entries.updateEntry(data);
 
 // The result would be something like the following:
 {
@@ -276,7 +276,7 @@ const data = {
   billed: true,
 };
 
-const result = await client.entries.updateEntry(data, callback);
+const result = await tickspot.entries.updateEntry(data, callback);
 // The result would be something like the following:
 {
   id: 1,
@@ -294,7 +294,7 @@ This method will delete the entry. The params you can send are the following:
 - [Required] entryId, entry unique identificator.
 
 ```javascript
-const result = await client.entries.deleteEntry("100773532");
+const result = await tickspot.entries.deleteEntry("100773532");
 
 // The result will be true if task was deleted
 ```

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -19,7 +19,7 @@ This method will return all opened projects. This method needs the following par
 - [Required] page, parameter for your request.
 
 ```javascript
-const result = await client.projects.listOpened(1);
+const result = await tickspot.projects.listOpened(1);
 
 // The result would be something like the following:
 [
@@ -66,7 +66,7 @@ const callback = (responseData) => {
   });
 };
 
-const result = await client.projects.listOpened(1, callback);
+const result = await tickspot.projects.listOpened(1, callback);
 
 // The result would be something like the following:
 [
@@ -84,7 +84,7 @@ This method will return all closed projects. This method needs the following par
 - [Required] page, parameter for your request.
 
 ```javascript
-const result = await client.projects.listClosed(1);
+const result = await tickspot.projects.listClosed(1);
 
 // The result would be something like the following:
 [
@@ -119,7 +119,7 @@ const callback = (responseData) => {
   });
 };
 
-const result = await client.projects.listClosed(1, callback);
+const result = await tickspot.projects.listClosed(1, callback);
 
 // The result would be something like the following:
 [
@@ -136,7 +136,7 @@ This method will return the specified project info. This method needs the follow
 - [Required] projectId, project unique identificator.
 
 ```javascript
-const result = await client.projects.getProject(16);
+const result = await tickspot.projects.getProject(16);
 // The result would be something like the following:
 [
   {
@@ -178,7 +178,7 @@ const callback = (responseData) => {
   };
 };
 
-const result = await client.projects.getProject(16, callback);
+const result = await tickspot.projects.getProject(16, callback);
 // The result would be something like the following:
 {
   id: 16;
@@ -210,7 +210,7 @@ const data = {
   recurring: false,
 };
 
-const result = await client.projects.create(data);
+const result = await tickspot.projects.create(data);
 
 // The result would be something like the following:
 {
@@ -249,7 +249,7 @@ const data = {
   recurring: false,
 };
 
-const result = await client.projects.create(data, callback);
+const result = await tickspot.projects.create(data, callback);
 
 // The result would be something like the following:
 { name: 'test #1', budget: 50 }
@@ -280,7 +280,7 @@ const data = {
   recurring: false,
 };
 
-const result = await client.projects.update(data);
+const result = await tickspot.projects.update(data);
 // The result would be something like the following:
 {
   id: 2210008,
@@ -319,7 +319,7 @@ const data = {
   recurring: false,
 };
 
-const result = await client.projects.update(data, callback);
+const result = await tickspot.projects.update(data, callback);
 // The result would be something like the following:
 { name: 'test #1', budget: 40 }
 ```
@@ -333,7 +333,7 @@ This method will delete a specific project. The params you can send are the foll
 **Warning**: The project and all time entries will be immediately deleted
 
 ```javascript
-const result = await client.projects.delete(123456);
+const result = await tickspot.projects.delete(123456);
 
 // The result will be true if the project was deleted
 ```
@@ -359,7 +359,7 @@ const params = {
   billable: true,
 };
 
-const result = await client.projects.listEntries(params);
+const result = await tickspot.projects.listEntries(params);
 // The result would be something like the following:
 [
   {
@@ -398,7 +398,7 @@ const callback = (responseData) =>
     };
   });
 
-const result = await client.projects.listEntries(params, callback);
+const result = await tickspot.projects.listEntries(params, callback);
 // The result would be something like the following:
 [
   {
@@ -419,7 +419,7 @@ This method will return all opened tasks for the project. This method needs the 
 - [Required] projectId, project unique identificator.
 
 ```javascript
-const result = await client.projects.listOpenedTasks(16);
+const result = await tickspot.projects.listOpenedTasks(16);
 // The result would be something like the following:
 [
   {
@@ -453,7 +453,7 @@ const callback = (responseData) => {
   });
 };
 
-const result = await client.projects.listOpenedTasks(16, callback);
+const result = await tickspot.projects.listOpenedTasks(16, callback);
 // The result would be something like the following:
 [
   { id: 123456, name: 'Task #1' },
@@ -469,7 +469,7 @@ This method will return all closed tasks for the project. This method needs the 
 - [Required] projectId, project unique identificator.
 
 ```javascript
-const result = await client.projects.listClosedTasks(16);
+const result = await tickspot.projects.listClosedTasks(16);
 // The result would be something like the following:
 [
   {
@@ -507,7 +507,7 @@ const callback = (responseData) => {
   });
 };
 
-const result = await client.projects.listClosedTasks(16, callback);
+const result = await tickspot.projects.listClosedTasks(16, callback);
 // The result would be something like the following:
 [
   { id: 123456, name: 'Task #1', day: 19, month: 0, year: 2022 },

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -15,7 +15,7 @@ This module allows you to interact with the Tickspot tasks.
 This method will return all opened tasks across all projects.
 
 ```javascript
-const result = await client.tasks.listOpened();
+const result = await tickspot.tasks.listOpened();
 
 // The result would be something like the following:
 [
@@ -52,7 +52,7 @@ const callback = (responseData) => {
   });
 };
 
-const result = await client.tasks.listOpened(callback);
+const result = await tickspot.tasks.listOpened(callback);
 
 // The result would be something like the following:
 [
@@ -73,7 +73,7 @@ const result = await client.tasks.listOpened(callback);
 This method will return all closed tasks across all projects.
 
 ```javascript
-const result = await client.tasks.listClosed();
+const result = await tickspot.tasks.listClosed();
 
 // The result would be something like the following:
 [
@@ -110,7 +110,7 @@ const callback = (responseData) => {
   });
 };
 
-const result = await client.tasks.listClosed(callback);
+const result = await tickspot.tasks.listClosed(callback);
 
 // The result would be something like the following:
 [
@@ -133,7 +133,7 @@ This method will return the specified task. This method needs the following para
 - [Required] taskId, task unique identificator.
 
 ```javascript
-const result = await client.tasks.getTask(1);
+const result = await tickspot.tasks.getTask(1);
 
 // The result would be something like the following:
 {
@@ -185,7 +185,7 @@ const callback = (responseData) => {
   };
 };
 
-const result = await client.tasks.getTask(1, callback);
+const result = await tickspot.tasks.getTask(1, callback);
 
 // The result would be something like the following:
 {
@@ -216,7 +216,7 @@ const data = {
   billable: false,
   dateClosed: '2022-01-20',
 };
-const result = await client.tasks.create(data);
+const result = await tickspot.tasks.create(data);
 // The result would be something like the following:
 {
   id: 123456,
@@ -249,7 +249,7 @@ const data = {
   billable: false,
   dateClosed: '2022-01-20',
 };
-const result = await client.tasks.create(data, callback);
+const result = await tickspot.tasks.create(data, callback);
 // The result would be something like the following:
 {
   id: 1,
@@ -280,7 +280,7 @@ const data = {
   projectId: 7890,
   dateClosed: '2022-01-20',
 };
-const result = await client.tasks.update(data);
+const result = await tickspot.tasks.update(data);
 // The result would be something like the following:
 {
   id: 123456,
@@ -315,7 +315,7 @@ const data = {
   projectId: 7890,
   dateClosed: '2022-01-20',
 };
-const result = await client.tasks.update(data, callback);
+const result = await tickspot.tasks.update(data, callback);
 // The result would be something like the following:
 {
   id: 1,
@@ -333,7 +333,7 @@ This method will delete a specific task. The params you can send are the followi
 **Warning**: Only tasks without any entries can be deleted
 
 ```javascript
-const result = await client.tasks.delete(123456);
+const result = await tickspot.tasks.delete(123456);
 
 // The result will be true if the task was deleted
 ```
@@ -358,7 +358,7 @@ const params = {
   endDate: "2021-11-09",
   billable: true,
 };
-const result = await client.tasks.listEntries(params);
+const result = await tickspot.tasks.listEntries(params);
 // The result would be something like the following:
 [
   {
@@ -397,7 +397,7 @@ const callback = (responseData) =>
     };
   });
 
-const result = await client.tasks.listEntries(params, callback);
+const result = await tickspot.tasks.listEntries(params, callback);
 // The result would be something like the following:
 [
   {

--- a/docs/users.md
+++ b/docs/users.md
@@ -11,7 +11,7 @@ This module allows you to interact with the Tickspot users.
 This method will return information about the users on the subscription. Non-administrators will only have visibility of themselves, while administrators will see everyone.
 
 ```javascript
-const result = await client.users.list();
+const result = await tickspot.users.list();
 
 // The result would be something like the following:
 [
@@ -46,7 +46,7 @@ const callback = (responseData) =>
     };
   });
 
-const result = await client.users.list(callback);
+const result = await tickspot.users.list(callback);
 // The result would be something like the following:
 [
   {
@@ -67,7 +67,7 @@ const result = await client.users.list(callback);
 This method will return users who have been deleted from the subscription and have time entries. Non-administrators will not have access.
 
 ```javascript
-const result = await client.users.listDeleted();
+const result = await tickspot.users.listDeleted();
 
 // The result would be something like the following:
 [
@@ -94,7 +94,7 @@ const callback = (responseData) =>
     };
   });
 
-const result = await client.users.listDeleted(callback);
+const result = await tickspot.users.listDeleted(callback);
 // The result would be something like the following:
 [
   {
@@ -125,7 +125,7 @@ const params = {
   endDate: "2021-11-09",
   billable: true,
 };
-const result = await client.users.listEntries(params);
+const result = await tickspot.users.listEntries(params);
 // The result would be something like the following:
 [
   {
@@ -162,7 +162,7 @@ const callback = (responseData) =>
       year: date.getFullYear(),
     };
   });
-const result = await client.users.listEntries(params, callback);
+const result = await tickspot.users.listEntries(params, callback);
 // The result would be something like the following:
 [
   {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import ClientV2 from './v2/client.js';
 
-const tickspot = ({
+const init = ({
   apiVersion,
   subscriptionId,
   apiToken,
@@ -14,4 +14,4 @@ const tickspot = ({
   }
 };
 
-export default tickspot;
+export default { init };

--- a/test/tickspot.test.js
+++ b/test/tickspot.test.js
@@ -1,15 +1,15 @@
 import Tickspot from '#src/index';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import Client from '#src/v2/client';
 
 describe('Tickspot.init', () => {
   it('when the tickspot method returns the client', () => {
-    const client = Tickspot.init({ apiVersion: 2, ...userInfo });
+    const client = Tickspot.init({ apiVersion: 2, ...credentials });
     expect(client).toBeInstanceOf(Client);
   });
 
   it('when the api version is not available', () => {
-    const client = Tickspot.init({ apiVersion: 3, ...userInfo });
+    const client = Tickspot.init({ apiVersion: 3, ...credentials });
     expect(client).toEqual(Error('The version is not available'));
   });
 });

--- a/test/tickspot.test.js
+++ b/test/tickspot.test.js
@@ -1,15 +1,15 @@
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import userInfo from '#test/v2/fixture/client';
 import Client from '#src/v2/client';
 
-describe('tickspot', () => {
+describe('Tickspot.init', () => {
   it('when the tickspot method returns the client', () => {
-    const client = tickspot({ apiVersion: 2, ...userInfo });
+    const client = Tickspot.init({ apiVersion: 2, ...userInfo });
     expect(client).toBeInstanceOf(Client);
   });
 
   it('when the api version is not available', () => {
-    const client = tickspot({ apiVersion: 3, ...userInfo });
+    const client = Tickspot.init({ apiVersion: 3, ...userInfo });
     expect(client).toEqual(Error('The version is not available'));
   });
 });

--- a/test/v2/baseResource.test.js
+++ b/test/v2/baseResource.test.js
@@ -1,5 +1,5 @@
 import BaseResource from '#src/v2/baseResource';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import { TICK_BASE_URL_START } from '#src/v2/constants';
 import {
   badResponseCallbackTests,
@@ -8,10 +8,10 @@ import {
 import { mockResolvedValueOnce, shouldHaveBeenCalledTimes } from './shared/utils/axios';
 
 jest.mock('axios');
-const auth = `Token token=${userInfo.apiToken}`;
+const auth = `Token token=${credentials.apiToken}`;
 const URL = TICK_BASE_URL_START;
 const resource = new BaseResource({
-  auth, baseURL: URL, agentEmail: userInfo.agentEmail,
+  auth, baseURL: URL, agentEmail: credentials.agentEmail,
 });
 
 describe('BaseResource', () => {

--- a/test/v2/client.test.js
+++ b/test/v2/client.test.js
@@ -1,28 +1,28 @@
 import Tickspot from '#src/index';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 
 describe('client', () => {
   it('when the client instance is created successfully', () => {
-    const client = Tickspot.init({ apiVersion: 2, ...userInfo });
-    const auth = `Token token=${userInfo.apiToken}`;
+    const client = Tickspot.init({ apiVersion: 2, ...credentials });
+    const auth = `Token token=${credentials.apiToken}`;
     expect(client.auth).toBe(auth);
   });
 
   it('when the subscriptionId field is missing', () => {
-    const userInfoMissed = { ...userInfo, subscriptionId: null };
-    const tickspotFailed = () => Tickspot.init({ apiVersion: 2, ...userInfoMissed });
+    const missingCredentials = { ...credentials, subscriptionId: null };
+    const tickspotFailed = () => Tickspot.init({ apiVersion: 2, ...missingCredentials });
     expect(tickspotFailed).toThrowError('subscriptionId is missing');
   });
 
   it('when the apiToken field is missing', () => {
-    const userInfoMissed = { ...userInfo, apiToken: null };
-    const tickspotFailed = () => Tickspot.init({ apiVersion: 2, ...userInfoMissed });
+    const missingCredentials = { ...credentials, apiToken: null };
+    const tickspotFailed = () => Tickspot.init({ apiVersion: 2, ...missingCredentials });
     expect(tickspotFailed).toThrowError('apiToken is missing');
   });
 
   it('when the agentEmail field is missing', () => {
-    const userInfoMissed = { ...userInfo, agentEmail: null };
-    const tickspotFailed = () => Tickspot.init({ apiVersion: 2, ...userInfoMissed });
+    const missingCredentials = { ...credentials, agentEmail: null };
+    const tickspotFailed = () => Tickspot.init({ apiVersion: 2, ...missingCredentials });
     expect(tickspotFailed).toThrowError('agentEmail is missing');
   });
 });

--- a/test/v2/client.test.js
+++ b/test/v2/client.test.js
@@ -1,28 +1,28 @@
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import userInfo from '#test/v2/fixture/client';
 
 describe('client', () => {
   it('when the client instance is created successfully', () => {
-    const client = tickspot({ apiVersion: 2, ...userInfo });
+    const client = Tickspot.init({ apiVersion: 2, ...userInfo });
     const auth = `Token token=${userInfo.apiToken}`;
     expect(client.auth).toBe(auth);
   });
 
   it('when the subscriptionId field is missing', () => {
     const userInfoMissed = { ...userInfo, subscriptionId: null };
-    const tickspotFailed = () => tickspot({ apiVersion: 2, ...userInfoMissed });
+    const tickspotFailed = () => Tickspot.init({ apiVersion: 2, ...userInfoMissed });
     expect(tickspotFailed).toThrowError('subscriptionId is missing');
   });
 
   it('when the apiToken field is missing', () => {
     const userInfoMissed = { ...userInfo, apiToken: null };
-    const tickspotFailed = () => tickspot({ apiVersion: 2, ...userInfoMissed });
+    const tickspotFailed = () => Tickspot.init({ apiVersion: 2, ...userInfoMissed });
     expect(tickspotFailed).toThrowError('apiToken is missing');
   });
 
   it('when the agentEmail field is missing', () => {
     const userInfoMissed = { ...userInfo, agentEmail: null };
-    const tickspotFailed = () => tickspot({ apiVersion: 2, ...userInfoMissed });
+    const tickspotFailed = () => Tickspot.init({ apiVersion: 2, ...userInfoMissed });
     expect(tickspotFailed).toThrowError('agentEmail is missing');
   });
 });

--- a/test/v2/fixture/credentials.js
+++ b/test/v2/fixture/credentials.js
@@ -1,7 +1,7 @@
-const userInfo = {
+const credentials = {
   subscriptionId: 123456,
   apiToken: 'ar425598573462y24ec1ceee728981663',
   agentEmail: 'user@kommit.co',
 };
 
-export default userInfo;
+export default credentials;

--- a/test/v2/resources/clients/createClient.test.js
+++ b/test/v2/resources/clients/createClient.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/clients/createClientFixture.js';
@@ -11,8 +11,8 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/clients.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/clients.json`;
 
 describe('#create', () => {
   const clientData = {
@@ -37,14 +37,14 @@ describe('#create', () => {
     });
 
     it('should create the new client', async () => {
-      const response = await client.clients.create(clientData);
+      const response = await tickspot.clients.create(clientData);
       expect(response.data.name).toBe(clientData.name);
     });
   });
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.clients.create(clientData);
+      await tickspot.clients.create(clientData);
     },
     URL,
     method: 'post',
@@ -52,7 +52,7 @@ describe('#create', () => {
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.clients.create(clientData, {});
+      await tickspot.clients.create(clientData, {});
     },
     method: 'post',
   });
@@ -62,7 +62,7 @@ describe('#create', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.clients.create(clientData, dataCallback);
+      const response = await tickspot.clients.create(clientData, dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -72,7 +72,7 @@ describe('#create', () => {
 
   wrongParamsTests({
     requestToExecute: async (requestParams) => {
-      await client.clients.create(requestParams);
+      await tickspot.clients.create(requestParams);
     },
     URL,
     method: 'post',

--- a/test/v2/resources/clients/createClient.test.js
+++ b/test/v2/resources/clients/createClient.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/clients/createClientFixture.js';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import {
@@ -11,7 +11,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/clients.json`;
 
 describe('#create', () => {

--- a/test/v2/resources/clients/deleteClient.test.js
+++ b/test/v2/resources/clients/deleteClient.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import { noContentResponse } from '#test/v2/fixture/shared/errorResponses';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import notFoundTests from '#test/v2/shared/notFound';
@@ -9,7 +9,7 @@ import wrongParamsTests from '#test/v2/shared/wrongParams';
 import notAcceptableTest from '#test/v2/shared/notAcceptable';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/clients/123456.json`;
 
 describe('#delete', () => {

--- a/test/v2/resources/clients/deleteClient.test.js
+++ b/test/v2/resources/clients/deleteClient.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import { noContentResponse } from '#test/v2/fixture/shared/errorResponses';
@@ -9,8 +9,8 @@ import wrongParamsTests from '#test/v2/shared/wrongParams';
 import notAcceptableTest from '#test/v2/shared/notAcceptable';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/clients/123456.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/clients/123456.json`;
 
 describe('#delete', () => {
   beforeEach(() => {
@@ -30,7 +30,7 @@ describe('#delete', () => {
     });
 
     it('should return true', async () => {
-      const response = await client.clients.delete(123456);
+      const response = await tickspot.clients.delete(123456);
 
       expect(axios.delete).toHaveBeenCalledTimes(1);
       expect(response).toEqual(true);
@@ -39,7 +39,7 @@ describe('#delete', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.clients.delete(123456);
+      await tickspot.clients.delete(123456);
     },
     URL,
     method: 'delete',
@@ -47,7 +47,7 @@ describe('#delete', () => {
 
   notFoundTests({
     requestToExecute: async () => {
-      await client.clients.delete(654321);
+      await tickspot.clients.delete(654321);
     },
     URL,
     method: 'delete',
@@ -55,7 +55,7 @@ describe('#delete', () => {
 
   wrongParamsTests({
     requestToExecute: async () => {
-      await client.clients.delete();
+      await tickspot.clients.delete();
     },
     URL,
     paramsList: ['clientId'],
@@ -64,7 +64,7 @@ describe('#delete', () => {
 
   notAcceptableTest({
     requestToExecute: async () => {
-      await client.clients.delete(123456);
+      await tickspot.clients.delete(123456);
     },
     URL,
     method: 'delete',

--- a/test/v2/resources/clients/getClient.test.js
+++ b/test/v2/resources/clients/getClient.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/clients/getClientFixture';
@@ -11,8 +11,8 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/clients/123456.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/clients/123456.json`;
 
 describe('#get', () => {
   beforeEach(() => {
@@ -32,7 +32,7 @@ describe('#get', () => {
     });
 
     it('should return the client information', async () => {
-      const response = await client.clients.get(123456);
+      const response = await tickspot.clients.get(123456);
 
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(response).toEqual(requestResponse.data);
@@ -41,14 +41,14 @@ describe('#get', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.clients.get(123456);
+      await tickspot.clients.get(123456);
     },
     URL,
   });
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.clients.get(123456, {});
+      await tickspot.clients.get(123456, {});
     },
   });
 
@@ -57,7 +57,7 @@ describe('#get', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.clients.get(123456, dataCallback);
+      const response = await tickspot.clients.get(123456, dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -66,7 +66,7 @@ describe('#get', () => {
 
   wrongParamsTests({
     requestToExecute: async () => {
-      await client.clients.get();
+      await tickspot.clients.get();
     },
     URL,
     paramsList: ['clientId'],

--- a/test/v2/resources/clients/getClient.test.js
+++ b/test/v2/resources/clients/getClient.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/clients/getClientFixture';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import {
@@ -11,7 +11,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/clients/123456.json`;
 
 describe('#get', () => {

--- a/test/v2/resources/clients/listClients.test.js
+++ b/test/v2/resources/clients/listClients.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/clients/listClientsFixture';
@@ -11,8 +11,8 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/clients.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/clients.json`;
 
 describe('#list', () => {
   beforeEach(() => {
@@ -32,7 +32,7 @@ describe('#list', () => {
     });
 
     it('should return a list with all clients', async () => {
-      const response = await client.clients.list(1);
+      const response = await tickspot.clients.list(1);
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(response).toBe(requestResponse.data);
     });
@@ -40,14 +40,14 @@ describe('#list', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.clients.list(1);
+      await tickspot.clients.list(1);
     },
     URL,
   });
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.clients.list(1, {});
+      await tickspot.clients.list(1, {});
     },
   });
 
@@ -56,7 +56,7 @@ describe('#list', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.clients.list(1, dataCallback);
+      const response = await tickspot.clients.list(1, dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -65,7 +65,7 @@ describe('#list', () => {
 
   wrongParamsTests({
     requestToExecute: async () => {
-      await client.clients.list();
+      await tickspot.clients.list();
     },
     URL,
     paramsList: ['page'],

--- a/test/v2/resources/clients/listClients.test.js
+++ b/test/v2/resources/clients/listClients.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/clients/listClientsFixture';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import {
@@ -11,7 +11,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/clients.json`;
 
 describe('#list', () => {

--- a/test/v2/resources/clients/updateClient.test.js
+++ b/test/v2/resources/clients/updateClient.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/clients/updateClientFixture.js';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import {
@@ -11,7 +11,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/clients/123456.json`;
 
 describe('#update', () => {

--- a/test/v2/resources/clients/updateClient.test.js
+++ b/test/v2/resources/clients/updateClient.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/clients/updateClientFixture.js';
@@ -11,8 +11,8 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/clients/123456.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/clients/123456.json`;
 
 describe('#update', () => {
   const clientData = {
@@ -38,14 +38,14 @@ describe('#update', () => {
     });
 
     it('should update the specific client', async () => {
-      const response = await client.clients.update(clientData);
+      const response = await tickspot.clients.update(clientData);
       expect(response.name).toBe(clientData.name);
     });
   });
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.clients.update(clientData);
+      await tickspot.clients.update(clientData);
     },
     URL,
     method: 'put',
@@ -53,7 +53,7 @@ describe('#update', () => {
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.clients.update(clientData, {});
+      await tickspot.clients.update(clientData, {});
     },
     method: 'put',
   });
@@ -63,7 +63,7 @@ describe('#update', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.clients.update(clientData, dataCallback);
+      const response = await tickspot.clients.update(clientData, dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -73,7 +73,7 @@ describe('#update', () => {
 
   wrongParamsTests({
     requestToExecute: async (requestParams) => {
-      await client.clients.update(requestParams);
+      await tickspot.clients.update(requestParams);
     },
     URL,
     method: 'put',

--- a/test/v2/resources/entries/createEntries.test.js
+++ b/test/v2/resources/entries/createEntries.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/entries/createEntryFixture';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import {
@@ -11,7 +11,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/entries.json`;
 
 describe('#create', () => {

--- a/test/v2/resources/entries/createEntries.test.js
+++ b/test/v2/resources/entries/createEntries.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/entries/createEntryFixture';
@@ -11,8 +11,8 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/entries.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/entries.json`;
 
 describe('#create', () => {
   const entryData = {
@@ -39,13 +39,13 @@ describe('#create', () => {
     });
 
     it('should return the tick data entry', async () => {
-      const response = await client.entries.create(entryData);
+      const response = await tickspot.entries.create(entryData);
 
       expect(response).toBe(requestResponse.data);
     });
 
     it('should create the tick entry', async () => {
-      const response = await client.entries.create(entryData);
+      const response = await tickspot.entries.create(entryData);
 
       expect(response.data.date).toBe(entryData.date);
       expect(response.data.notes).toBe(entryData.notes);
@@ -54,7 +54,7 @@ describe('#create', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.entries.create(entryData);
+      await tickspot.entries.create(entryData);
     },
     URL,
     method: 'post',
@@ -62,7 +62,7 @@ describe('#create', () => {
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.entries.create(entryData, {});
+      await tickspot.entries.create(entryData, {});
     },
     method: 'post',
   });
@@ -72,7 +72,7 @@ describe('#create', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.entries.create(entryData, dataCallback);
+      const response = await tickspot.entries.create(entryData, dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -82,7 +82,7 @@ describe('#create', () => {
 
   wrongParamsTests({
     requestToExecute: async (requestParams) => {
-      await client.entries.create(requestParams);
+      await tickspot.entries.create(requestParams);
     },
     URL,
     method: 'post',

--- a/test/v2/resources/entries/deleteEntry.test.js
+++ b/test/v2/resources/entries/deleteEntry.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import { noContentResponse } from '#test/v2/fixture/shared/errorResponses';
@@ -8,8 +8,8 @@ import notFoundTests from '#test/v2/shared/notFound';
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/entries/123456.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/entries/123456.json`;
 
 describe('#delete', () => {
   beforeEach(() => {
@@ -29,12 +29,12 @@ describe('#delete', () => {
     });
 
     it('should return true', async () => {
-      const response = await client.entries.delete('123456');
+      const response = await tickspot.entries.delete('123456');
 
       expect(axios.delete).toHaveBeenCalledTimes(1);
       expect(axios.delete).toHaveBeenCalledWith(
         URL,
-        { headers: client.entries.DEFAULT_HEADERS },
+        { headers: tickspot.entries.DEFAULT_HEADERS },
       );
 
       expect(response).toEqual(true);
@@ -43,7 +43,7 @@ describe('#delete', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.entries.delete('123456');
+      await tickspot.entries.delete('123456');
     },
     URL,
     method: 'delete',
@@ -51,7 +51,7 @@ describe('#delete', () => {
 
   notFoundTests({
     requestToExecute: async () => {
-      await client.entries.delete('654321');
+      await tickspot.entries.delete('654321');
     },
     URL,
     method: 'delete',
@@ -59,7 +59,7 @@ describe('#delete', () => {
 
   wrongParamsTests({
     requestToExecute: async () => {
-      await client.entries.delete();
+      await tickspot.entries.delete();
     },
     URL,
     paramsList: ['entryId'],

--- a/test/v2/resources/entries/deleteEntry.test.js
+++ b/test/v2/resources/entries/deleteEntry.test.js
@@ -1,14 +1,14 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import { noContentResponse } from '#test/v2/fixture/shared/errorResponses';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import notFoundTests from '#test/v2/shared/notFound';
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/entries/123456.json`;
 
 describe('#delete', () => {

--- a/test/v2/resources/entries/getEntry.test.js
+++ b/test/v2/resources/entries/getEntry.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/entries/getEntryFixture';
 import notFoundTests from '#test/v2/shared/notFound';
 import authenticationErrorTests from '#test/v2/shared/authentication';
@@ -12,7 +12,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/entries/123456.json`;
 
 describe('#get', () => {

--- a/test/v2/resources/entries/getEntry.test.js
+++ b/test/v2/resources/entries/getEntry.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/entries/getEntryFixture';
@@ -12,8 +12,8 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/entries/123456.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/entries/123456.json`;
 
 describe('#get', () => {
   beforeEach(() => {
@@ -33,12 +33,12 @@ describe('#get', () => {
     });
 
     it('should return the entry information', async () => {
-      const response = await client.entries.get('123456');
+      const response = await tickspot.entries.get('123456');
 
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(axios.get).toHaveBeenCalledWith(
         URL,
-        { headers: client.entries.DEFAULT_HEADERS },
+        { headers: tickspot.entries.DEFAULT_HEADERS },
       );
 
       expect(response).toEqual(requestResponse.data);
@@ -47,21 +47,21 @@ describe('#get', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.entries.get('123456');
+      await tickspot.entries.get('123456');
     },
     URL,
   });
 
   notFoundTests({
     requestToExecute: async () => {
-      await client.entries.get('123456');
+      await tickspot.entries.get('123456');
     },
     URL,
   });
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.entries.get('123456', {});
+      await tickspot.entries.get('123456', {});
     },
   });
 
@@ -70,7 +70,7 @@ describe('#get', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.entries.get('123456', dataCallback);
+      const response = await tickspot.entries.get('123456', dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -79,7 +79,7 @@ describe('#get', () => {
 
   wrongParamsTests({
     requestToExecute: async () => {
-      await client.entries.get();
+      await tickspot.entries.get();
     },
     URL,
     paramsList: ['entryId'],

--- a/test/v2/resources/entries/listEntries.test.js
+++ b/test/v2/resources/entries/listEntries.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/entries/listEntriesFixture';
 import responseFactory from '#test/v2/factories/responseFactory';
@@ -11,8 +11,8 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/entries.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/entries.json`;
 
 describe('#list', () => {
   const params = {
@@ -38,13 +38,13 @@ describe('#list', () => {
     });
 
     it('should return the list of tick entries', async () => {
-      const response = await client.entries.list(params);
+      const response = await tickspot.entries.list(params);
 
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(axios.get).toHaveBeenCalledWith(
         URL,
         {
-          headers: client.entries.DEFAULT_HEADERS,
+          headers: tickspot.entries.DEFAULT_HEADERS,
           params: { end_date: '2021-11-09', start_date: '2021-11-08', user_id: 'userId' },
         },
       );
@@ -54,14 +54,14 @@ describe('#list', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.entries.list(params);
+      await tickspot.entries.list(params);
     },
     URL,
   });
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.entries.list(params, {});
+      await tickspot.entries.list(params, {});
     },
   });
 
@@ -70,7 +70,7 @@ describe('#list', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.entries.list(params, dataCallback);
+      const response = await tickspot.entries.list(params, dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -79,7 +79,7 @@ describe('#list', () => {
 
   wrongParamsTests({
     requestToExecute: async (requestParams) => {
-      await client.entries.list(requestParams);
+      await tickspot.entries.list(requestParams);
     },
     URL,
     requestData: params,

--- a/test/v2/resources/entries/listEntries.test.js
+++ b/test/v2/resources/entries/listEntries.test.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/entries/listEntriesFixture';
 import responseFactory from '#test/v2/factories/responseFactory';
 import authenticationErrorTests from '#test/v2/shared/authentication';
@@ -11,7 +11,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/entries.json`;
 
 describe('#list', () => {

--- a/test/v2/resources/entries/updateEntry.test.js
+++ b/test/v2/resources/entries/updateEntry.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/entries/updateEntryFixture';
@@ -12,8 +12,8 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/entries/123456.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/entries/123456.json`;
 
 describe('#update', () => {
   const requestResponse = responseFactory({
@@ -44,7 +44,7 @@ describe('#update', () => {
         billed: false,
       };
 
-      const response = await client.entries.update(data);
+      const response = await tickspot.entries.update(data);
 
       expect(axios.put).toHaveBeenCalledTimes(1);
       expect(response).toEqual(requestResponse.data);
@@ -63,7 +63,7 @@ describe('#update', () => {
         billed: false,
       };
 
-      await client.entries.update(data);
+      await tickspot.entries.update(data);
     },
     URL,
     method: 'put',
@@ -76,7 +76,7 @@ describe('#update', () => {
         taskId: 111,
       };
 
-      await client.entries.update(data);
+      await tickspot.entries.update(data);
     },
     URL,
     method: 'put',
@@ -88,7 +88,7 @@ describe('#update', () => {
         entryId: 654321,
         taskId: 111,
       };
-      await client.entries.update(data, {});
+      await tickspot.entries.update(data, {});
     },
   });
 
@@ -102,7 +102,7 @@ describe('#update', () => {
         entryId: 654321,
         taskId: 111,
       };
-      const response = await client.entries.update(data, dataCallback);
+      const response = await tickspot.entries.update(data, dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -112,7 +112,7 @@ describe('#update', () => {
 
   wrongParamsTests({
     requestToExecute: async (requestParams) => {
-      await client.entries.update(requestParams);
+      await tickspot.entries.update(requestParams);
     },
     URL,
     requestData: {},

--- a/test/v2/resources/entries/updateEntry.test.js
+++ b/test/v2/resources/entries/updateEntry.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/entries/updateEntryFixture';
 import notFoundTests from '#test/v2/shared/notFound';
 import unprocessableEntityTests from '#test/v2/shared/unprocessableEntity';
@@ -12,7 +12,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/entries/123456.json`;
 
 describe('#update', () => {

--- a/test/v2/resources/projects/createProject.test.js
+++ b/test/v2/resources/projects/createProject.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/projects/createProjectFixture.js';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import {
@@ -11,7 +11,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/projects.json`;
 
 describe('#create', () => {

--- a/test/v2/resources/projects/createProject.test.js
+++ b/test/v2/resources/projects/createProject.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/projects/createProjectFixture.js';
@@ -11,8 +11,8 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/projects.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/projects.json`;
 
 describe('#create', () => {
   const projectData = {
@@ -42,14 +42,14 @@ describe('#create', () => {
     });
 
     it('should create the new project', async () => {
-      const response = await client.projects.create(projectData);
+      const response = await tickspot.projects.create(projectData);
       expect(response.data.name).toBe(projectData.name);
     });
   });
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.projects.create(projectData);
+      await tickspot.projects.create(projectData);
     },
     URL,
     method: 'post',
@@ -57,7 +57,7 @@ describe('#create', () => {
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.projects.create(projectData, {});
+      await tickspot.projects.create(projectData, {});
     },
     method: 'post',
   });
@@ -67,7 +67,7 @@ describe('#create', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.projects.create(projectData, dataCallback);
+      const response = await tickspot.projects.create(projectData, dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -77,7 +77,7 @@ describe('#create', () => {
 
   wrongParamsTests({
     requestToExecute: async (requestParams) => {
-      await client.projects.create(requestParams);
+      await tickspot.projects.create(requestParams);
     },
     URL,
     method: 'post',

--- a/test/v2/resources/projects/deleteProject.test.js
+++ b/test/v2/resources/projects/deleteProject.test.js
@@ -1,14 +1,14 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import { noContentResponse } from '#test/v2/fixture/shared/errorResponses';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import notFoundTests from '#test/v2/shared/notFound';
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/projects/123456.json`;
 
 describe('#delete', () => {

--- a/test/v2/resources/projects/deleteProject.test.js
+++ b/test/v2/resources/projects/deleteProject.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import { noContentResponse } from '#test/v2/fixture/shared/errorResponses';
@@ -8,8 +8,8 @@ import notFoundTests from '#test/v2/shared/notFound';
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/projects/123456.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/projects/123456.json`;
 
 describe('#delete', () => {
   beforeEach(() => {
@@ -29,12 +29,12 @@ describe('#delete', () => {
     });
 
     it('should return true', async () => {
-      const response = await client.projects.delete(123456);
+      const response = await tickspot.projects.delete(123456);
 
       expect(axios.delete).toHaveBeenCalledTimes(1);
       expect(axios.delete).toHaveBeenCalledWith(
         URL,
-        { headers: client.projects.DEFAULT_HEADERS },
+        { headers: tickspot.projects.DEFAULT_HEADERS },
       );
 
       expect(response).toEqual(true);
@@ -43,7 +43,7 @@ describe('#delete', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.projects.delete(123456);
+      await tickspot.projects.delete(123456);
     },
     URL,
     method: 'delete',
@@ -51,7 +51,7 @@ describe('#delete', () => {
 
   notFoundTests({
     requestToExecute: async () => {
-      await client.projects.delete(654321);
+      await tickspot.projects.delete(654321);
     },
     URL,
     method: 'delete',
@@ -59,7 +59,7 @@ describe('#delete', () => {
 
   wrongParamsTests({
     requestToExecute: async () => {
-      await client.projects.delete();
+      await tickspot.projects.delete();
     },
     URL,
     paramsList: ['projectId'],

--- a/test/v2/resources/projects/getProject.test.js
+++ b/test/v2/resources/projects/getProject.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/projects/getProjectFixture';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import {
@@ -11,7 +11,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/projects/16.json`;
 
 describe('#get', () => {

--- a/test/v2/resources/projects/getProject.test.js
+++ b/test/v2/resources/projects/getProject.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/projects/getProjectFixture';
@@ -11,8 +11,8 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/projects/16.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/projects/16.json`;
 
 describe('#get', () => {
   beforeEach(() => {
@@ -32,12 +32,12 @@ describe('#get', () => {
     });
 
     it('should return the project information', async () => {
-      const response = await client.projects.get('16');
+      const response = await tickspot.projects.get('16');
 
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(axios.get).toHaveBeenCalledWith(
         URL,
-        { headers: client.projects.DEFAULT_HEADERS },
+        { headers: tickspot.projects.DEFAULT_HEADERS },
       );
 
       expect(response).toEqual(requestResponse.data);
@@ -46,14 +46,14 @@ describe('#get', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.projects.get('16');
+      await tickspot.projects.get('16');
     },
     URL,
   });
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.projects.get('16', {});
+      await tickspot.projects.get('16', {});
     },
   });
 
@@ -62,7 +62,7 @@ describe('#get', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.projects.get('16', dataCallback);
+      const response = await tickspot.projects.get('16', dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -71,7 +71,7 @@ describe('#get', () => {
 
   wrongParamsTests({
     requestToExecute: async () => {
-      await client.projects.get();
+      await tickspot.projects.get();
     },
     URL,
     paramsList: ['projectId'],

--- a/test/v2/resources/projects/listClosedTasks.test.js
+++ b/test/v2/resources/projects/listClosedTasks.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/tasks/closedTasksFixture';
@@ -11,8 +11,8 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/projects/123/tasks.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/projects/123/tasks.json`;
 
 describe('#listClosedTasks', () => {
   beforeEach(() => {
@@ -32,7 +32,7 @@ describe('#listClosedTasks', () => {
     });
 
     it('should return all closed tasks for the project', async () => {
-      const response = await client.projects.listClosedTasks(123);
+      const response = await tickspot.projects.listClosedTasks(123);
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(response).toBe(requestResponse.data);
     });
@@ -40,14 +40,14 @@ describe('#listClosedTasks', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.projects.listClosedTasks(123);
+      await tickspot.projects.listClosedTasks(123);
     },
     URL,
   });
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.projects.listClosedTasks(123, {});
+      await tickspot.projects.listClosedTasks(123, {});
     },
   });
 
@@ -56,7 +56,7 @@ describe('#listClosedTasks', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.projects.listClosedTasks(123, dataCallback);
+      const response = await tickspot.projects.listClosedTasks(123, dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -65,7 +65,7 @@ describe('#listClosedTasks', () => {
 
   wrongParamsTests({
     requestToExecute: async () => {
-      await client.projects.listClosedTasks();
+      await tickspot.projects.listClosedTasks();
     },
     URL,
     paramsList: ['projectId'],

--- a/test/v2/resources/projects/listClosedTasks.test.js
+++ b/test/v2/resources/projects/listClosedTasks.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/tasks/closedTasksFixture';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import {
@@ -11,7 +11,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/projects/123/tasks.json`;
 
 describe('#listClosedTasks', () => {

--- a/test/v2/resources/projects/listEntries.test.js
+++ b/test/v2/resources/projects/listEntries.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/entries/listEntriesFixture';
@@ -11,8 +11,8 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/projects/123/entries.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/projects/123/entries.json`;
 
 describe('#listEntries', () => {
   const params = {
@@ -38,7 +38,7 @@ describe('#listEntries', () => {
     });
 
     it('should return a list with all entries related to a project', async () => {
-      const response = await client.projects.listEntries(params);
+      const response = await tickspot.projects.listEntries(params);
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(response).toBe(requestResponse.data);
     });
@@ -46,14 +46,14 @@ describe('#listEntries', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.projects.listEntries(params);
+      await tickspot.projects.listEntries(params);
     },
     URL,
   });
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.projects.listEntries(params, {});
+      await tickspot.projects.listEntries(params, {});
     },
   });
 
@@ -62,7 +62,7 @@ describe('#listEntries', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.projects.listEntries(params, dataCallback);
+      const response = await tickspot.projects.listEntries(params, dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -71,7 +71,7 @@ describe('#listEntries', () => {
 
   wrongParamsTests({
     requestToExecute: async (requestParams) => {
-      await client.projects.listEntries(requestParams);
+      await tickspot.projects.listEntries(requestParams);
     },
     URL,
     requestData: params,

--- a/test/v2/resources/projects/listEntries.test.js
+++ b/test/v2/resources/projects/listEntries.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/entries/listEntriesFixture';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import {
@@ -11,7 +11,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/projects/123/entries.json`;
 
 describe('#listEntries', () => {

--- a/test/v2/resources/projects/listOpenedTasks.test.js
+++ b/test/v2/resources/projects/listOpenedTasks.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/tasks/openedTasksFixture';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import {
@@ -11,7 +11,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/projects/123/tasks.json`;
 
 describe('#listOpenedTasks', () => {

--- a/test/v2/resources/projects/listOpenedTasks.test.js
+++ b/test/v2/resources/projects/listOpenedTasks.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/tasks/openedTasksFixture';
@@ -11,8 +11,8 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/projects/123/tasks.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/projects/123/tasks.json`;
 
 describe('#listOpenedTasks', () => {
   beforeEach(() => {
@@ -32,7 +32,7 @@ describe('#listOpenedTasks', () => {
     });
 
     it('should return all opened tasks for the project', async () => {
-      const response = await client.projects.listOpenedTasks(123);
+      const response = await tickspot.projects.listOpenedTasks(123);
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(response).toBe(requestResponse.data);
     });
@@ -40,14 +40,14 @@ describe('#listOpenedTasks', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.projects.listOpenedTasks(123);
+      await tickspot.projects.listOpenedTasks(123);
     },
     URL,
   });
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.projects.listOpenedTasks(123, {});
+      await tickspot.projects.listOpenedTasks(123, {});
     },
   });
 
@@ -56,7 +56,7 @@ describe('#listOpenedTasks', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.projects.listOpenedTasks(123, dataCallback);
+      const response = await tickspot.projects.listOpenedTasks(123, dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -65,7 +65,7 @@ describe('#listOpenedTasks', () => {
 
   wrongParamsTests({
     requestToExecute: async () => {
-      await client.projects.listOpenedTasks();
+      await tickspot.projects.listOpenedTasks();
     },
     URL,
     paramsList: ['projectId'],

--- a/test/v2/resources/projects/listProjects.test.js
+++ b/test/v2/resources/projects/listProjects.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/projects/listProjectsFixture';
@@ -11,13 +11,13 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
 
 const methods = ['listOpened', 'listClosed'];
 
 const getUrl = (method) => (method === 'listOpened'
-  ? `${client.baseURL}/projects.json`
-  : `${client.baseURL}/projects/closed.json`);
+  ? `${tickspot.baseURL}/projects.json`
+  : `${tickspot.baseURL}/projects/closed.json`);
 
 describe.each(methods)('#%s', (method) => {
   beforeEach(() => {
@@ -39,7 +39,7 @@ describe.each(methods)('#%s', (method) => {
     });
 
     it('should return a list of projects', async () => {
-      const response = await client.projects[`${method}`](1);
+      const response = await tickspot.projects[`${method}`](1);
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(response).toBe(requestResponse.data);
     });
@@ -47,14 +47,14 @@ describe.each(methods)('#%s', (method) => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.projects[`${method}`](1);
+      await tickspot.projects[`${method}`](1);
     },
     URL,
   });
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.projects[`${method}`](1, {});
+      await tickspot.projects[`${method}`](1, {});
     },
   });
 
@@ -63,7 +63,7 @@ describe.each(methods)('#%s', (method) => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.projects[`${method}`](1, dataCallback);
+      const response = await tickspot.projects[`${method}`](1, dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -72,7 +72,7 @@ describe.each(methods)('#%s', (method) => {
 
   wrongParamsTests({
     requestToExecute: async () => {
-      await client.projects[`${method}`]();
+      await tickspot.projects[`${method}`]();
     },
     URL,
     paramsList: ['page'],

--- a/test/v2/resources/projects/listProjects.test.js
+++ b/test/v2/resources/projects/listProjects.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/projects/listProjectsFixture';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import {
@@ -11,7 +11,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 
 const methods = ['listOpened', 'listClosed'];
 

--- a/test/v2/resources/projects/updateProject.test.js
+++ b/test/v2/resources/projects/updateProject.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/projects/createProjectFixture.js';
@@ -11,8 +11,8 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/projects/123456.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/projects/123456.json`;
 
 describe('#update', () => {
   const projectData = {
@@ -43,14 +43,14 @@ describe('#update', () => {
     });
 
     it('should update the specific project', async () => {
-      const response = await client.projects.update(projectData);
+      const response = await tickspot.projects.update(projectData);
       expect(response.data.name).toBe(projectData.name);
     });
   });
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.projects.update(projectData);
+      await tickspot.projects.update(projectData);
     },
     URL,
     method: 'put',
@@ -58,7 +58,7 @@ describe('#update', () => {
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.projects.update(projectData, {});
+      await tickspot.projects.update(projectData, {});
     },
     method: 'put',
   });
@@ -68,7 +68,7 @@ describe('#update', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.projects.update(projectData, dataCallback);
+      const response = await tickspot.projects.update(projectData, dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -78,7 +78,7 @@ describe('#update', () => {
 
   wrongParamsTests({
     requestToExecute: async (requestParams) => {
-      await client.projects.update(requestParams);
+      await tickspot.projects.update(requestParams);
     },
     URL,
     method: 'put',

--- a/test/v2/resources/projects/updateProject.test.js
+++ b/test/v2/resources/projects/updateProject.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/projects/createProjectFixture.js';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import {
@@ -11,7 +11,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/projects/123456.json`;
 
 describe('#update', () => {

--- a/test/v2/resources/tasks/createTask.test.js
+++ b/test/v2/resources/tasks/createTask.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/tasks/createTaskFixture';
 import responseFactory from '#test/v2/factories/responseFactory';
@@ -11,8 +11,8 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/tasks.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/tasks.json`;
 
 describe('#create', () => {
   const params = {
@@ -37,13 +37,13 @@ describe('#create', () => {
     });
 
     it('should return the data of the created task', async () => {
-      const response = await client.tasks.create(params);
+      const response = await tickspot.tasks.create(params);
 
       expect(axios.post).toHaveBeenCalledTimes(1);
       expect(axios.post).toHaveBeenCalledWith(
         URL,
         { name: 'Test', project_id: 7890 },
-        { headers: client.tasks.DEFAULT_HEADERS },
+        { headers: tickspot.tasks.DEFAULT_HEADERS },
       );
       expect(response).toEqual(requestResponse.data);
     });
@@ -51,7 +51,7 @@ describe('#create', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.tasks.create(params);
+      await tickspot.tasks.create(params);
     },
     URL,
     method: 'post',
@@ -59,7 +59,7 @@ describe('#create', () => {
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.tasks.create(params, {});
+      await tickspot.tasks.create(params, {});
     },
     method: 'post',
   });
@@ -70,7 +70,7 @@ describe('#create', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.tasks.create(params, dataCallback);
+      const response = await tickspot.tasks.create(params, dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -79,7 +79,7 @@ describe('#create', () => {
 
   wrongParamsTests({
     requestToExecute: async (requestParams) => {
-      await client.tasks.create(requestParams);
+      await tickspot.tasks.create(requestParams);
     },
     URL,
     requestData: params,

--- a/test/v2/resources/tasks/createTask.test.js
+++ b/test/v2/resources/tasks/createTask.test.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/tasks/createTaskFixture';
 import responseFactory from '#test/v2/factories/responseFactory';
 import authenticationErrorTests from '#test/v2/shared/authentication';
@@ -11,7 +11,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/tasks.json`;
 
 describe('#create', () => {

--- a/test/v2/resources/tasks/deleteTask.test.js
+++ b/test/v2/resources/tasks/deleteTask.test.js
@@ -1,14 +1,14 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import { noContentResponse } from '#test/v2/fixture/shared/errorResponses';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import notFoundTests from '#test/v2/shared/notFound';
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/tasks/123456.json`;
 
 describe('#delete', () => {

--- a/test/v2/resources/tasks/deleteTask.test.js
+++ b/test/v2/resources/tasks/deleteTask.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import { noContentResponse } from '#test/v2/fixture/shared/errorResponses';
@@ -8,8 +8,8 @@ import notFoundTests from '#test/v2/shared/notFound';
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/tasks/123456.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/tasks/123456.json`;
 
 describe('#delete', () => {
   beforeEach(() => {
@@ -29,12 +29,12 @@ describe('#delete', () => {
     });
 
     it('should return true', async () => {
-      const response = await client.tasks.delete('123456');
+      const response = await tickspot.tasks.delete('123456');
 
       expect(axios.delete).toHaveBeenCalledTimes(1);
       expect(axios.delete).toHaveBeenCalledWith(
         URL,
-        { headers: client.tasks.DEFAULT_HEADERS },
+        { headers: tickspot.tasks.DEFAULT_HEADERS },
       );
 
       expect(response).toEqual(true);
@@ -43,7 +43,7 @@ describe('#delete', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.tasks.delete('123456');
+      await tickspot.tasks.delete('123456');
     },
     URL,
     method: 'delete',
@@ -51,7 +51,7 @@ describe('#delete', () => {
 
   notFoundTests({
     requestToExecute: async () => {
-      await client.tasks.delete('654321');
+      await tickspot.tasks.delete('654321');
     },
     URL,
     method: 'delete',
@@ -59,7 +59,7 @@ describe('#delete', () => {
 
   wrongParamsTests({
     requestToExecute: async () => {
-      await client.tasks.delete();
+      await tickspot.tasks.delete();
     },
     URL,
     paramsList: ['taskId'],

--- a/test/v2/resources/tasks/getTask.test.js
+++ b/test/v2/resources/tasks/getTask.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/tasks/getTaskFixture';
@@ -12,8 +12,8 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/tasks/123456.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/tasks/123456.json`;
 
 describe('#get', () => {
   beforeEach(() => {
@@ -33,7 +33,7 @@ describe('#get', () => {
     });
 
     it('should return the task data', async () => {
-      const response = await client.tasks.get(123456);
+      const response = await tickspot.tasks.get(123456);
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(response).toBe(requestResponse.data);
     });
@@ -41,21 +41,21 @@ describe('#get', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.tasks.get(123456);
+      await tickspot.tasks.get(123456);
     },
     URL,
   });
 
   notFoundTests({
     requestToExecute: async () => {
-      await client.tasks.get(654321);
+      await tickspot.tasks.get(654321);
     },
     URL,
   });
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.tasks.get(123456, {});
+      await tickspot.tasks.get(123456, {});
     },
   });
 
@@ -64,7 +64,7 @@ describe('#get', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.tasks.get(123456, dataCallback);
+      const response = await tickspot.tasks.get(123456, dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -73,7 +73,7 @@ describe('#get', () => {
 
   wrongParamsTests({
     requestToExecute: async () => {
-      await client.tasks.get();
+      await tickspot.tasks.get();
     },
     URL,
     paramsList: ['taskId'],

--- a/test/v2/resources/tasks/getTask.test.js
+++ b/test/v2/resources/tasks/getTask.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/tasks/getTaskFixture';
 import notFoundTests from '#test/v2/shared/notFound';
 import authenticationErrorTests from '#test/v2/shared/authentication';
@@ -12,7 +12,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/tasks/123456.json`;
 
 describe('#get', () => {

--- a/test/v2/resources/tasks/listClosed.test.js
+++ b/test/v2/resources/tasks/listClosed.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/tasks/closedTasksFixture';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import {
@@ -10,7 +10,7 @@ import {
 } from '#test/v2/shared/responseCallback';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/tasks/closed.json`;
 
 describe('#listClosed', () => {

--- a/test/v2/resources/tasks/listClosed.test.js
+++ b/test/v2/resources/tasks/listClosed.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/tasks/closedTasksFixture';
@@ -10,8 +10,8 @@ import {
 } from '#test/v2/shared/responseCallback';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/tasks/closed.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/tasks/closed.json`;
 
 describe('#listClosed', () => {
   beforeEach(() => {
@@ -31,7 +31,7 @@ describe('#listClosed', () => {
     });
 
     it('should return a list of closed tasks', async () => {
-      const response = await client.tasks.listClosed();
+      const response = await tickspot.tasks.listClosed();
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(response).toBe(requestResponse.data);
     });
@@ -39,14 +39,14 @@ describe('#listClosed', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.tasks.listClosed();
+      await tickspot.tasks.listClosed();
     },
     URL,
   });
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.tasks.listClosed({});
+      await tickspot.tasks.listClosed({});
     },
   });
 
@@ -55,7 +55,7 @@ describe('#listClosed', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.tasks.listClosed(dataCallback);
+      const response = await tickspot.tasks.listClosed(dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,

--- a/test/v2/resources/tasks/listEntries.test.js
+++ b/test/v2/resources/tasks/listEntries.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/entries/listEntriesFixture';
@@ -11,8 +11,8 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/tasks/123/entries.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/tasks/123/entries.json`;
 
 describe('#listEntries', () => {
   const params = {
@@ -39,7 +39,7 @@ describe('#listEntries', () => {
     });
 
     it('should return a list with all entries related to a task', async () => {
-      const response = await client.tasks.listEntries(params);
+      const response = await tickspot.tasks.listEntries(params);
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(response).toBe(requestResponse.data);
     });
@@ -47,14 +47,14 @@ describe('#listEntries', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.tasks.listEntries(params);
+      await tickspot.tasks.listEntries(params);
     },
     URL,
   });
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.tasks.listEntries(params, {});
+      await tickspot.tasks.listEntries(params, {});
     },
   });
 
@@ -63,7 +63,7 @@ describe('#listEntries', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.tasks.listEntries(params, dataCallback);
+      const response = await tickspot.tasks.listEntries(params, dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -72,7 +72,7 @@ describe('#listEntries', () => {
 
   wrongParamsTests({
     requestToExecute: async (requestParams) => {
-      await client.tasks.listEntries(requestParams);
+      await tickspot.tasks.listEntries(requestParams);
     },
     URL,
     requestData: params,

--- a/test/v2/resources/tasks/listEntries.test.js
+++ b/test/v2/resources/tasks/listEntries.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/entries/listEntriesFixture';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import {
@@ -11,7 +11,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/tasks/123/entries.json`;
 
 describe('#listEntries', () => {

--- a/test/v2/resources/tasks/listOpened.test.js
+++ b/test/v2/resources/tasks/listOpened.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/tasks/openedTasksFixture';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import {
@@ -10,7 +10,7 @@ import {
 } from '#test/v2/shared/responseCallback';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/tasks.json`;
 
 describe('#listOpened', () => {

--- a/test/v2/resources/tasks/listOpened.test.js
+++ b/test/v2/resources/tasks/listOpened.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/tasks/openedTasksFixture';
@@ -10,8 +10,8 @@ import {
 } from '#test/v2/shared/responseCallback';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/tasks.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/tasks.json`;
 
 describe('#listOpened', () => {
   beforeEach(() => {
@@ -31,7 +31,7 @@ describe('#listOpened', () => {
     });
 
     it('should return a list with all opened tasks across all projects', async () => {
-      const response = await client.tasks.listOpened();
+      const response = await tickspot.tasks.listOpened();
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(response).toBe(requestResponse.data);
     });
@@ -39,14 +39,14 @@ describe('#listOpened', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.tasks.listOpened();
+      await tickspot.tasks.listOpened();
     },
     URL,
   });
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.tasks.listOpened({});
+      await tickspot.tasks.listOpened({});
     },
   });
 
@@ -55,7 +55,7 @@ describe('#listOpened', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.tasks.listOpened(dataCallback);
+      const response = await tickspot.tasks.listOpened(dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,

--- a/test/v2/resources/tasks/updateTask.test.js
+++ b/test/v2/resources/tasks/updateTask.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/tasks/updateTaskFixture';
 import responseFactory from '#test/v2/factories/responseFactory';
@@ -11,8 +11,8 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/tasks/123456.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/tasks/123456.json`;
 
 describe('#update', () => {
   const params = {
@@ -37,13 +37,13 @@ describe('#update', () => {
     });
 
     it('should return the task updated data', async () => {
-      const response = await client.tasks.update(params);
+      const response = await tickspot.tasks.update(params);
 
       expect(axios.put).toHaveBeenCalledTimes(1);
       expect(axios.put).toHaveBeenCalledWith(
         URL,
         { budget: 10 },
-        { headers: client.tasks.DEFAULT_HEADERS },
+        { headers: tickspot.tasks.DEFAULT_HEADERS },
       );
       expect(response).toEqual(requestResponse.data);
     });
@@ -51,7 +51,7 @@ describe('#update', () => {
 
   describe('when invalid parameters are sent to the update method', () => {
     it('should throw an error specifying that the budget parameter is invalid', async () => {
-      await expect(client.tasks.update({ taskId: 123456 }))
+      await expect(tickspot.tasks.update({ taskId: 123456 }))
         .rejects.toThrow('budget field cannot be undefined');
 
       expect(axios.put).not.toHaveBeenCalled();
@@ -60,7 +60,7 @@ describe('#update', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.tasks.update(params);
+      await tickspot.tasks.update(params);
     },
     URL,
     method: 'put',
@@ -68,7 +68,7 @@ describe('#update', () => {
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.tasks.update(params, {});
+      await tickspot.tasks.update(params, {});
     },
     method: 'put',
   });
@@ -79,7 +79,7 @@ describe('#update', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.tasks.update(params, dataCallback);
+      const response = await tickspot.tasks.update(params, dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -88,7 +88,7 @@ describe('#update', () => {
 
   wrongParamsTests({
     requestToExecute: async (requestParams) => {
-      await client.tasks.update(requestParams);
+      await tickspot.tasks.update(requestParams);
     },
     URL,
     requestData: params,

--- a/test/v2/resources/tasks/updateTask.test.js
+++ b/test/v2/resources/tasks/updateTask.test.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/tasks/updateTaskFixture';
 import responseFactory from '#test/v2/factories/responseFactory';
 import authenticationErrorTests from '#test/v2/shared/authentication';
@@ -11,7 +11,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/tasks/123456.json`;
 
 describe('#update', () => {

--- a/test/v2/resources/users/listDeletedUsers.test.js
+++ b/test/v2/resources/users/listDeletedUsers.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import listDeletedUsersFixture from '#test/v2/fixture/users/listDeletedUsersFixture';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import {
@@ -10,7 +10,7 @@ import {
 } from '#test/v2/shared/responseCallback';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/users/deleted.json`;
 
 describe('#listDeleted', () => {

--- a/test/v2/resources/users/listDeletedUsers.test.js
+++ b/test/v2/resources/users/listDeletedUsers.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import listDeletedUsersFixture from '#test/v2/fixture/users/listDeletedUsersFixture';
@@ -10,8 +10,8 @@ import {
 } from '#test/v2/shared/responseCallback';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/users/deleted.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/users/deleted.json`;
 
 describe('#listDeleted', () => {
   beforeEach(() => {
@@ -31,7 +31,7 @@ describe('#listDeleted', () => {
     });
 
     it('should return a list with all deleted users', async () => {
-      const response = await client.users.listDeleted();
+      const response = await tickspot.users.listDeleted();
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(response).toBe(requestResponse.data);
     });
@@ -39,14 +39,14 @@ describe('#listDeleted', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.users.listDeleted();
+      await tickspot.users.listDeleted();
     },
     URL,
   });
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.users.listDeleted({});
+      await tickspot.users.listDeleted({});
     },
   });
 
@@ -55,7 +55,7 @@ describe('#listDeleted', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.users.listDeleted(dataCallback);
+      const response = await tickspot.users.listDeleted(dataCallback);
       return [response, dataCallback];
     },
     responseData: listDeletedUsersFixture,

--- a/test/v2/resources/users/listEntries.test.js
+++ b/test/v2/resources/users/listEntries.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import successfulResponseData from '#test/v2/fixture/entries/listEntriesFixture';
@@ -11,8 +11,8 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/users/123/entries.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/users/123/entries.json`;
 
 describe('#listEntries', () => {
   const params = {
@@ -38,7 +38,7 @@ describe('#listEntries', () => {
     });
 
     it('should return a list with all entries related to a user', async () => {
-      const response = await client.users.listEntries(params);
+      const response = await tickspot.users.listEntries(params);
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(response).toBe(requestResponse.data);
     });
@@ -46,14 +46,14 @@ describe('#listEntries', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.users.listEntries(params);
+      await tickspot.users.listEntries(params);
     },
     URL,
   });
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.users.listEntries(params, {});
+      await tickspot.users.listEntries(params, {});
     },
   });
 
@@ -62,7 +62,7 @@ describe('#listEntries', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.users.listEntries(params, dataCallback);
+      const response = await tickspot.users.listEntries(params, dataCallback);
       return [response, dataCallback];
     },
     responseData: successfulResponseData,
@@ -71,7 +71,7 @@ describe('#listEntries', () => {
 
   wrongParamsTests({
     requestToExecute: async (requestParams) => {
-      await client.users.listEntries(requestParams);
+      await tickspot.users.listEntries(requestParams);
     },
     URL,
     requestData: params,

--- a/test/v2/resources/users/listEntries.test.js
+++ b/test/v2/resources/users/listEntries.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import successfulResponseData from '#test/v2/fixture/entries/listEntriesFixture';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import {
@@ -11,7 +11,7 @@ import {
 import wrongParamsTests from '#test/v2/shared/wrongParams';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/users/123/entries.json`;
 
 describe('#listEntries', () => {

--- a/test/v2/resources/users/listUsers.test.js
+++ b/test/v2/resources/users/listUsers.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import tickspot from '#src/index';
+import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
 import userInfo from '#test/v2/fixture/client';
 import listUsersFixture from '#test/v2/fixture/users/listUsersFixture';
@@ -10,8 +10,8 @@ import {
 } from '#test/v2/shared/responseCallback';
 
 jest.mock('axios');
-const client = tickspot({ apiVersion: 2, ...userInfo });
-const URL = `${client.baseURL}/users.json`;
+const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const URL = `${tickspot.baseURL}/users.json`;
 
 describe('#list', () => {
   beforeEach(() => {
@@ -31,7 +31,7 @@ describe('#list', () => {
     });
 
     it('should return a list with all users', async () => {
-      const response = await client.users.list();
+      const response = await tickspot.users.list();
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(response).toBe(requestResponse.data);
     });
@@ -39,14 +39,14 @@ describe('#list', () => {
 
   authenticationErrorTests({
     requestToExecute: async () => {
-      await client.users.list();
+      await tickspot.users.list();
     },
     URL,
   });
 
   badResponseCallbackTests({
     requestToExecute: async () => {
-      await client.users.list({});
+      await tickspot.users.list({});
     },
   });
 
@@ -55,7 +55,7 @@ describe('#list', () => {
       const dataCallback = jest
         .fn()
         .mockImplementation((data) => ({ newStructure: { ...data } }));
-      const response = await client.users.list(dataCallback);
+      const response = await tickspot.users.list(dataCallback);
       return [response, dataCallback];
     },
     responseData: listUsersFixture,

--- a/test/v2/resources/users/listUsers.test.js
+++ b/test/v2/resources/users/listUsers.test.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Tickspot from '#src/index';
 import responseFactory from '#test/v2/factories/responseFactory';
-import userInfo from '#test/v2/fixture/client';
+import credentials from '#test/v2/fixture/credentials';
 import listUsersFixture from '#test/v2/fixture/users/listUsersFixture';
 import authenticationErrorTests from '#test/v2/shared/authentication';
 import {
@@ -10,7 +10,7 @@ import {
 } from '#test/v2/shared/responseCallback';
 
 jest.mock('axios');
-const tickspot = Tickspot.init({ apiVersion: 2, ...userInfo });
+const tickspot = Tickspot.init({ apiVersion: 2, ...credentials });
 const URL = `${tickspot.baseURL}/users.json`;
 
 describe('#list', () => {


### PR DESCRIPTION
Issue #20

### Description
:wave: This PR changes a few small things in the project to avoid confusions.
- Changed the documentation to instantiate the lib using `Tickspot.init` and naming the client variable `tickspot`, this way we avoid confusions with the `clients` module.
  ```javascript
   // Before
   const client = tickspot(.....)
   client.clients.someFunction()

   // After
   const tickspot = Tickspot.init(....)
   tickspot.clients.someFunction()
  ```
- Rename the `userInfo` mock to `credetials` to avoid confusions with the `users` module mocks.

### CheckList
- [x] Create examples on how to use it as a lib.